### PR TITLE
fix: use UTF-8 byte length for AIRS topic constraints

### DIFF
--- a/src/core/constraints.ts
+++ b/src/core/constraints.ts
@@ -14,12 +14,17 @@ export const MAX_COMBINED_LENGTH = 1000;
 /** @deprecated Use MAX_EXAMPLES */
 const MAX_EXAMPLES_COUNT = MAX_EXAMPLES;
 
+/** UTF-8 byte length — AIRS API enforces limits in bytes, not JS characters. */
+function byteLen(s: string): number {
+  return Buffer.byteLength(s, 'utf8');
+}
+
 export function validateName(name: string): ValidationError[] {
   const errors: ValidationError[] = [];
   if (!name || name.length === 0) {
     errors.push({ field: 'name', message: 'Name is required' });
-  } else if (name.length > MAX_NAME_LENGTH) {
-    errors.push({ field: 'name', message: `Name must be at most ${MAX_NAME_LENGTH} characters` });
+  } else if (byteLen(name) > MAX_NAME_LENGTH) {
+    errors.push({ field: 'name', message: `Name must be at most ${MAX_NAME_LENGTH} bytes` });
   }
   return errors;
 }
@@ -28,10 +33,10 @@ export function validateDescription(description: string): ValidationError[] {
   const errors: ValidationError[] = [];
   if (!description || description.length === 0) {
     errors.push({ field: 'description', message: 'Description is required' });
-  } else if (description.length > MAX_DESCRIPTION_LENGTH) {
+  } else if (byteLen(description) > MAX_DESCRIPTION_LENGTH) {
     errors.push({
       field: 'description',
-      message: `Description must be at most ${MAX_DESCRIPTION_LENGTH} characters`,
+      message: `Description must be at most ${MAX_DESCRIPTION_LENGTH} bytes`,
     });
   }
   return errors;
@@ -41,10 +46,10 @@ export function validateExample(example: string, index: number): ValidationError
   const errors: ValidationError[] = [];
   if (!example || example.length === 0) {
     errors.push({ field: `examples[${index}]`, message: `Example ${index} is required` });
-  } else if (example.length > MAX_EXAMPLE_LENGTH) {
+  } else if (byteLen(example) > MAX_EXAMPLE_LENGTH) {
     errors.push({
       field: `examples[${index}]`,
-      message: `Example ${index} must be at most ${MAX_EXAMPLE_LENGTH} characters`,
+      message: `Example ${index} must be at most ${MAX_EXAMPLE_LENGTH} bytes`,
     });
   }
   return errors;
@@ -71,14 +76,14 @@ export function validateTopic(topic: CustomTopic): ValidationError[] {
   errors.push(...validateExamples(topic.examples));
 
   const combined =
-    topic.name.length +
-    topic.description.length +
-    topic.examples.reduce((sum, ex) => sum + ex.length, 0);
+    byteLen(topic.name) +
+    byteLen(topic.description) +
+    topic.examples.reduce((sum, ex) => sum + byteLen(ex), 0);
 
   if (combined > MAX_COMBINED_LENGTH) {
     errors.push({
       field: 'topic',
-      message: `Combined length (${combined}) exceeds ${MAX_COMBINED_LENGTH} characters`,
+      message: `Combined length (${combined}) exceeds ${MAX_COMBINED_LENGTH} bytes`,
     });
   }
 

--- a/src/llm/service.ts
+++ b/src/llm/service.ts
@@ -31,21 +31,36 @@ import {
 
 const MAX_RETRIES = 3;
 
-/** Clamp topic fields to fit Prisma AIRS constraints (including combined limit) */
-function clampTopic(topic: CustomTopicOutput): CustomTopicOutput {
-  const name = topic.name.slice(0, MAX_NAME_LENGTH);
-  let description = topic.description.slice(0, MAX_DESCRIPTION_LENGTH);
-  const examples = topic.examples.slice(0, MAX_EXAMPLES).map((e) => e.slice(0, MAX_EXAMPLE_LENGTH));
+/** Truncate a string so its UTF-8 byte length does not exceed maxBytes. */
+function sliceToBytes(s: string, maxBytes: number): string {
+  while (Buffer.byteLength(s, 'utf8') > maxBytes) {
+    s = s.slice(0, -1);
+  }
+  return s;
+}
 
-  // Enforce combined length limit by dropping examples from the end, then trimming description
+/** UTF-8 byte length of a string. */
+function byteLen(s: string): number {
+  return Buffer.byteLength(s, 'utf8');
+}
+
+/** Clamp topic fields to fit Prisma AIRS constraints (byte-aware, including combined limit) */
+function clampTopic(topic: CustomTopicOutput): CustomTopicOutput {
+  const name = sliceToBytes(topic.name, MAX_NAME_LENGTH);
+  let description = sliceToBytes(topic.description, MAX_DESCRIPTION_LENGTH);
+  const examples = topic.examples
+    .slice(0, MAX_EXAMPLES)
+    .map((e) => sliceToBytes(e, MAX_EXAMPLE_LENGTH));
+
+  // Enforce combined byte-length limit by dropping examples from the end, then trimming description
   const combined = () =>
-    name.length + description.length + examples.reduce((s, e) => s + e.length, 0);
+    byteLen(name) + byteLen(description) + examples.reduce((s, e) => s + byteLen(e), 0);
   while (combined() > MAX_COMBINED_LENGTH && examples.length > 1) {
     examples.pop();
   }
   if (combined() > MAX_COMBINED_LENGTH) {
     const overflow = combined() - MAX_COMBINED_LENGTH;
-    description = description.slice(0, description.length - overflow);
+    description = sliceToBytes(description, byteLen(description) - overflow);
   }
 
   return { name, description, examples };

--- a/tests/unit/core/constraints.spec.ts
+++ b/tests/unit/core/constraints.spec.ts
@@ -132,5 +132,20 @@ describe('constraints', () => {
       // 100 + 250 + 200 + 200 + 250 = 1000
       expect(validateTopic(topic)).toEqual([]);
     });
+
+    it('rejects description with multi-byte chars exceeding 250 bytes', () => {
+      // 248 ASCII chars + 1 em dash (3 bytes) = 251 bytes > 250
+      const desc = 'a'.repeat(248) + '—';
+      expect(desc.length).toBe(249); // JS char count is 249
+      const errors = validateDescription(desc);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('250');
+    });
+
+    it('accepts multi-byte description within 250 bytes', () => {
+      // 247 ASCII chars + 1 em dash (3 bytes) = 250 bytes
+      const desc = 'a'.repeat(247) + '—';
+      expect(validateDescription(desc)).toEqual([]);
+    });
   });
 });

--- a/tests/unit/llm/service.spec.ts
+++ b/tests/unit/llm/service.spec.ts
@@ -94,7 +94,16 @@ describe('LangChainLlmService', () => {
       const model = createMockModel({ ...validTopic, examples: [longExample] });
       const service = new LangChainLlmService(model as any);
       const result = await service.generateTopic('weapons', 'block');
-      expect(result.examples[0].length).toBeLessThanOrEqual(250);
+      expect(Buffer.byteLength(result.examples[0], 'utf8')).toBeLessThanOrEqual(250);
+    });
+
+    it('clamps description with multi-byte chars by byte length', async () => {
+      // 248 ASCII + 1 em dash (3 bytes) = 251 bytes, should be trimmed to ≤250 bytes
+      const desc = 'a'.repeat(248) + '—';
+      const model = createMockModel({ ...validTopic, description: desc });
+      const service = new LangChainLlmService(model as any);
+      const result = await service.generateTopic('weapons', 'block');
+      expect(Buffer.byteLength(result.description, 'utf8')).toBeLessThanOrEqual(250);
     });
 
     it('drops examples when combined length exceeds limit', async () => {


### PR DESCRIPTION
## Summary
- AIRS API enforces field limits in bytes, not JS characters
- Multi-byte chars (em dash `—` = 3 bytes) caused `clampTopic()` to produce 250-char strings that exceeded the 250-byte API limit, crashing mid-loop
- `clampTopic()` and `validateTopic()` now use `Buffer.byteLength()` + `sliceToBytes()` helper

## Test plan
- [x] `pnpm test` — 168 tests passing (added multi-byte char tests)
- [x] `pnpm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)