### PR TITLE
fix(docs): correct env var names and gemini defaults

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -40,7 +40,7 @@ Create `~/.daystrom/config.json` for persistent defaults:
 | Gemini Bedrock | `gemini-bedrock` | `gemini-2.0-flash` | AWS creds |
 
 !!! note "Claude Vertex region"
-    The `claude-vertex` provider defaults to the `global` region, not `us-central1`. Override with the `VERTEX_REGION` env var if needed.
+    The `claude-vertex` provider defaults to the `global` region, not `us-central1`. Override with the `CLOUD_ML_REGION` env var if needed.
 
 ## Tuning Parameters
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -57,9 +57,9 @@ Optional JSON file at `~/.daystrom/config.json`. Keys use camelCase matching the
 | `claude-api` | `claude-opus-4-6` |
 | `claude-vertex` | `claude-opus-4-6` |
 | `claude-bedrock` | `anthropic.claude-opus-4-6-v1` |
-| `gemini-api` | per-provider default |
-| `gemini-vertex` | per-provider default |
-| `gemini-bedrock` | per-provider default |
+| `gemini-api` | `gemini-2.0-flash` |
+| `gemini-vertex` | `gemini-2.0-flash` |
+| `gemini-bedrock` | `gemini-2.0-flash` |
 
 !!! warning "Concurrency tuning"
     Setting `scanConcurrency` above 5 risks rate limiting from the AIRS scan API. Increase cautiously.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -13,9 +13,7 @@ All environment variables used by Daystrom, grouped by category. See `.env.examp
 | `ANTHROPIC_API_KEY` | `claude-api` | Anthropic API key (`sk-ant-...`) |
 | `GOOGLE_API_KEY` | `gemini-api` | Google AI API key |
 | `GOOGLE_CLOUD_PROJECT` | `claude-vertex`, `gemini-vertex` | GCP project ID |
-| `GOOGLE_CLOUD_LOCATION` | `gemini-vertex` | GCP region (default: `us-central1`) |
-| `CLOUD_ML_REGION` | `claude-vertex` | GCP region for Claude (default: `global`) |
-| `ANTHROPIC_VERTEX_PROJECT_ID` | `claude-vertex` | GCP project for Anthropic Vertex |
+| `GOOGLE_CLOUD_LOCATION` | `claude-vertex`, `gemini-vertex` | GCP region (default: `us-central1`; claude-vertex uses `global`) |
 | `AWS_REGION` | `claude-bedrock`, `gemini-bedrock` | AWS region (default: `us-east-1`) |
 | `AWS_ACCESS_KEY_ID` | `claude-bedrock`*, `gemini-bedrock`* | IAM access key |
 | `AWS_SECRET_ACCESS_KEY` | `claude-bedrock`*, `gemini-bedrock`* | IAM secret key |


### PR DESCRIPTION
## Summary
- Fix `VERTEX_REGION` → `CLOUD_ML_REGION` in getting-started config guide
- Show actual `gemini-2.0-flash` defaults instead of "per-provider default" in reference
- Remove SDK-internal env vars (`CLOUD_ML_REGION`, `ANTHROPIC_VERTEX_PROJECT_ID`) from env vars reference — Daystrom uses `GOOGLE_CLOUD_LOCATION`

## Test plan
- [x] All 192 tests pass
- [x] Lint and typecheck clean
- [x] Docs build verified via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)