### PR TITLE
ci: add npm publish workflow with OIDC provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Typecheck
+        run: pnpm tsc --noEmit
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Publish to npm
+        run: pnpm publish --access public --no-git-checks


### PR DESCRIPTION
## Summary
- Add `publish.yml` workflow triggered on GitHub releases
- Uses OIDC provenance (same pattern as prisma-airs-sdk)
- Requires `npm` GitHub environment with npm OIDC trust configured
- Runs full CI (lint, typecheck, test, build) before `pnpm publish --access public`

## Test plan
- [x] Workflow syntax valid
- [x] CI checks pass on this PR
- [ ] Will verify npm publish by re-creating v1.0.0 release after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)