### PR TITLE
fix(ci): use npm publish with OIDC provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,4 +37,4 @@ jobs:
         run: pnpm run build
 
       - name: Publish to npm
-        run: pnpm publish --access public --no-git-checks
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Switch from `pnpm publish` to `npm publish --provenance` for OIDC auth compatibility
- `pnpm publish` doesn't properly use the OIDC token from `actions/setup-node`

## Test plan
- [x] CI passes
- [ ] npm publish triggers on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)