### PR TITLE
fix: add repository field for npm OIDC provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdot65/daystrom.git"
+  },
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.14.4",


### PR DESCRIPTION
## Summary
- Add `repository` field to `package.json`
- Required by npm provenance to verify OIDC claims against the GitHub repo
- Without it, `npm publish --provenance` fails with E404

## Test plan
- [x] CI passes
- [ ] npm publish succeeds on next release re-trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)