### PR TITLE
deps: bump prisma-airs-sdk 0.2.0 → 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.14.4",
-    "@cdot65/prisma-airs-sdk": "^0.2.0",
+    "@cdot65/prisma-airs-sdk": "^0.4.0",
     "@inquirer/prompts": "^8.3.0",
     "@langchain/anthropic": "^1.3.21",
     "@langchain/aws": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.14.4
         version: 0.14.4(zod@3.25.76)
       '@cdot65/prisma-airs-sdk':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.4.0
+        version: 0.4.0
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.0(@types/node@22.19.13)
@@ -314,8 +314,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cdot65/prisma-airs-sdk@0.2.0':
-    resolution: {integrity: sha512-ZYBOmDLq7+780cSfyahvJv8Z2FL5IU5vBFrtPkFdBPyVc+t7OEbY4v0gdJ1kwO5KdCno5D/8EYVyY8o3UMOCJw==}
+  '@cdot65/prisma-airs-sdk@0.4.0':
+    resolution: {integrity: sha512-5ibkdw24wHK7ysnA5he0LTC65LdyqlYvpDz7IGGHsm6LIdMorFxdTC2XxVRizG2dx8nsr7Til/gCAU8/mY79hQ==}
     engines: {node: '>=18'}
 
   '@cfworker/json-schema@4.1.1':
@@ -2434,7 +2434,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.5':
     optional: true
 
-  '@cdot65/prisma-airs-sdk@0.2.0':
+  '@cdot65/prisma-airs-sdk@0.4.0':
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## Summary
- Bump `@cdot65/prisma-airs-sdk` from `^0.2.0` to `^0.4.0`
- Fully backward compatible — no code changes needed
- SDK adds Model Security, Red Team domains, typed enums, JSDoc, shared retry logic

## Test plan
- [x] `pnpm test` — 192/192 pass
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm run lint` — clean
- [ ] CI actions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)