### PR TITLE
fix(ci): add format check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
+      - run: pnpm run format:check
 
   typecheck:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
+    "format:check": "biome format .",
     "docker:build": "docker build -t daystrom:local .",
     "docker:build:amd64": "docker buildx build --platform linux/amd64 --load -t daystrom:local-amd64 .",
     "docker:build:arm64": "docker buildx build --platform linux/arm64 --load -t daystrom:local-arm64 .",


### PR DESCRIPTION
## Summary
- Add `format:check` script to `package.json` (`biome format .` — read-only check)
- Add `pnpm run format:check` step to CI lint job
- Ensures format violations are caught in PRs

Closes #12

## Test plan
- [x] `pnpm run format:check` passes locally
- [x] `pnpm run lint` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm test` — 192/192 pass
- [ ] CI actions pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)