### PR TITLE
docs: fix inaccurate LoopEvent documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ pnpm test:e2e              # E2E tests (requires real creds, opt-in)
 pnpm run lint              # Biome check
 pnpm run lint:fix          # Biome check --write
 pnpm run format            # Biome format --write
+pnpm run format:check      # Biome format (check only, no write)
 
 # Type-check
 pnpm tsc --noEmit
@@ -97,7 +98,9 @@ tests/
 
 ### Core Loop (`src/core/loop.ts`)
 - `runLoop()` async generator yields typed `LoopEvent` discriminated unions
-- Events: `iteration:start`, `generate:complete`, `apply:complete`, `test:progress`, `evaluate:complete`, `analyze:complete`, `iteration:complete`, `loop:complete`, `loop:paused`, `memory:loaded`, `memory:extracted`
+- Events yielded by `runLoop()`: `iteration:start`, `generate:complete`, `apply:complete`, `test:progress`, `evaluate:complete`, `analyze:complete`, `iteration:complete`, `memory:extracted` (if memory enabled), `loop:complete`
+- Events defined in `LoopEvent` union but **not yielded** by `runLoop()`: `loop:paused` (reserved for future use), `memory:loaded` (emitted by CLI before loop starts)
+- `apply:complete` is yielded but intentionally unhandled in CLI commands (no user-facing output needed)
 - Topic name **locked after iteration 1** — only description+examples change thereafter
 - Stop: `coverage >= targetCoverage` (default 0.9). Coverage = `min(TPR, TNR)`
 

--- a/docs/architecture/core-loop.md
+++ b/docs/architecture/core-loop.md
@@ -30,22 +30,29 @@ flowchart TD
 
 The generator yields events at each stage of the loop. Consumers (e.g., the CLI renderer) iterate the generator and dispatch on the event `type` field.
 
+### Yielded by `runLoop()`
+
 | Event | Payload | When |
 |-------|---------|------|
 | `iteration:start` | iteration number | Start of each iteration |
 | `generate:complete` | `CustomTopic` | After LLM generates or improves topic |
-| `apply:complete` | topic ID | After topic deployed to AIRS |
-| `test:progress` | test index, result | Per-test scan completion |
+| `apply:complete` | topic ID | After topic deployed to AIRS (yielded but intentionally unhandled in CLI) |
+| `test:progress` | completed count, total | Per-test scan completion |
 | `evaluate:complete` | `EfficacyMetrics` | After metrics computed |
 | `analyze:complete` | `AnalysisReport` | After FP/FN analysis |
 | `iteration:complete` | `IterationResult` | Full iteration summary |
-| `loop:complete` | best iteration, all results | Terminal: target reached or max iterations |
-| `loop:paused` | current state | Terminal: run interrupted |
-| `memory:loaded` | learning count | Memory injected at start |
-| `memory:extracted` | learning count | Learnings extracted post-loop |
+| `memory:extracted` | learning count | Learnings extracted post-loop (only if memory enabled) |
+| `loop:complete` | best iteration, run state | Terminal: target reached or max iterations |
+
+### Defined but not yielded by `runLoop()`
+
+| Event | Payload | Status |
+|-------|---------|--------|
+| `loop:paused` | current state | Reserved for future use — not currently yielded |
+| `memory:loaded` | learning count | Emitted by CLI command (`generate.ts`) before the loop starts, not by the generator itself |
 
 !!! tip "Terminal Events"
-    `loop:complete` and `loop:paused` are terminal events. After either is yielded, the generator returns and no further events are produced. A paused run can be resumed via the `resume` command.
+    `loop:complete` is the terminal event. After it is yielded, the generator returns and no further events are produced. `loop:paused` is defined in the type union for future use but is not currently yielded.
 
 ## Topic Name Locking
 


### PR DESCRIPTION
## Summary
- Fix CLAUDE.md event list to distinguish yielded vs defined-only events
- Fix docs/architecture/core-loop.md event table with same corrections
- Add `format:check` command to CLAUDE.md Commands section
- `memory:loaded` emitted by CLI before loop, not by `runLoop()`
- `loop:paused` reserved for future use, not currently yielded
- `apply:complete` yielded but intentionally unhandled in CLI

Closes #13

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm test` — 192/192 pass
- [ ] CI actions pass
- [ ] Docs site builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)