### PR TITLE
refactor: extract shared byteLen(), remove deprecated constant

### DIFF
--- a/src/core/constraints.ts
+++ b/src/core/constraints.ts
@@ -11,11 +11,8 @@ export const MAX_EXAMPLE_LENGTH = 250;
 export const MAX_EXAMPLES = 5;
 export const MAX_COMBINED_LENGTH = 1000;
 
-/** @deprecated Use MAX_EXAMPLES */
-const MAX_EXAMPLES_COUNT = MAX_EXAMPLES;
-
 /** UTF-8 byte length — AIRS API enforces limits in bytes, not JS characters. */
-function byteLen(s: string): number {
+export function byteLen(s: string): number {
   return Buffer.byteLength(s, 'utf8');
 }
 
@@ -57,10 +54,10 @@ export function validateExample(example: string, index: number): ValidationError
 
 export function validateExamples(examples: string[]): ValidationError[] {
   const errors: ValidationError[] = [];
-  if (examples.length > MAX_EXAMPLES_COUNT) {
+  if (examples.length > MAX_EXAMPLES) {
     errors.push({
       field: 'examples',
-      message: `At most ${MAX_EXAMPLES_COUNT} examples allowed`,
+      message: `At most ${MAX_EXAMPLES} examples allowed`,
     });
   }
   for (let i = 0; i < examples.length; i++) {

--- a/src/llm/service.ts
+++ b/src/llm/service.ts
@@ -1,5 +1,6 @@
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import {
+  byteLen,
   MAX_COMBINED_LENGTH,
   MAX_DESCRIPTION_LENGTH,
   MAX_EXAMPLE_LENGTH,
@@ -37,11 +38,6 @@ function sliceToBytes(s: string, maxBytes: number): string {
     s = s.slice(0, -1);
   }
   return s;
-}
-
-/** UTF-8 byte length of a string. */
-function byteLen(s: string): number {
-  return Buffer.byteLength(s, 'utf8');
 }
 
 /** Clamp topic fields to fit Prisma AIRS constraints (byte-aware, including combined limit) */

--- a/tests/unit/core/constraints.spec.ts
+++ b/tests/unit/core/constraints.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  byteLen,
   validateDescription,
   validateExample,
   validateExamples,
@@ -9,6 +10,21 @@ import {
 import type { CustomTopic } from '../../../src/core/types.js';
 
 describe('constraints', () => {
+  describe('byteLen', () => {
+    it('returns byte length for ASCII strings', () => {
+      expect(byteLen('hello')).toBe(5);
+    });
+
+    it('returns byte length for multi-byte characters', () => {
+      // em dash is 3 bytes in UTF-8
+      expect(byteLen('\u2014')).toBe(3);
+    });
+
+    it('returns 0 for empty string', () => {
+      expect(byteLen('')).toBe(0);
+    });
+  });
+
   describe('validateName', () => {
     it('accepts valid name', () => {
       expect(validateName('My Topic')).toEqual([]);


### PR DESCRIPTION
## Summary
- Export `byteLen()` from `src/core/constraints.ts` as single source of truth
- Import in `src/llm/service.ts`, remove duplicate definition
- Replace deprecated `MAX_EXAMPLES_COUNT` with `MAX_EXAMPLES` in `validateExamples()`
- Add 3 new tests for `byteLen()` (ASCII, multi-byte, empty string)

Closes #14

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm test` — 195/195 pass (3 new)
- [ ] CI actions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)