### PR TITLE
docs: remove unused env vars from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,20 +12,13 @@ GOOGLE_API_KEY=
 GOOGLE_CLOUD_PROJECT=
 GOOGLE_CLOUD_LOCATION=us-central1
 
-# Anthropic Vertex AI (claude-vertex provider)
-CLOUD_ML_REGION=global
-ANTHROPIC_VERTEX_PROJECT_ID=
-
 # AWS Bedrock
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
-# ── Scan API (API key or bearer token auth) ──────────────────────────
+# ── Scan API ──────────────────────────────────────────────────────────
 PANW_AI_SEC_API_KEY=
-PANW_AI_SEC_API_TOKEN=
-PANW_AI_SEC_PROFILE_NAME=
-# PANW_AI_SEC_API_ENDPOINT=https://service.api.aisecurity.paloaltonetworks.com
 
 # ── Management API (OAuth2 client credentials) ──────────────────────
 PANW_MGMT_CLIENT_ID=

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -40,7 +40,7 @@ Create `~/.daystrom/config.json` for persistent defaults:
 | Gemini Bedrock | `gemini-bedrock` | `gemini-2.0-flash` | AWS creds |
 
 !!! note "Claude Vertex region"
-    The `claude-vertex` provider defaults to the `global` region, not `us-central1`. Override with the `CLOUD_ML_REGION` env var if needed.
+    The `claude-vertex` provider defaults to the `global` region, not `us-central1`. Override with `GOOGLE_CLOUD_LOCATION` if needed.
 
 ## Tuning Parameters
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -27,13 +27,7 @@ All environment variables used by Daystrom, grouped by category. See `.env.examp
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `PANW_AI_SEC_API_KEY` | Yes* | AI Security scan API key |
-| `PANW_AI_SEC_API_TOKEN` | -- | Alternative: bearer token |
-| `PANW_AI_SEC_PROFILE_NAME` | -- | Default profile name |
-| `PANW_AI_SEC_API_ENDPOINT` | -- | Custom endpoint (default: `https://service.api.aisecurity.paloaltonetworks.com`) |
-
-!!! info
-    *Either `PANW_AI_SEC_API_KEY` or `PANW_AI_SEC_API_TOKEN` is required.
+| `PANW_AI_SEC_API_KEY` | Yes | AI Security scan API key |
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove `CLOUD_ML_REGION`, `ANTHROPIC_VERTEX_PROJECT_ID` from `.env.example` (use `GOOGLE_CLOUD_LOCATION`/`GOOGLE_CLOUD_PROJECT`)
- Remove `PANW_AI_SEC_API_TOKEN`, `PANW_AI_SEC_PROFILE_NAME` from `.env.example` (not consumed by config loader)
- Fix `CLOUD_ML_REGION` reference in `docs/getting-started/configuration.md` to `GOOGLE_CLOUD_LOCATION`
- Remove `PANW_AI_SEC_API_TOKEN`/`PANW_AI_SEC_PROFILE_NAME` rows from env var reference docs

Closes #15

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm test` — 195/195 pass
- [ ] CI actions pass
- [ ] Docs site builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)