### PR TITLE
docs: add JSDoc to core interfaces and public API

### DIFF
--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -16,10 +16,12 @@ export type { CreateCustomTopicRequest, SdkCustomTopic };
 // ---------------------------------------------------------------------------
 // Scan result — normalized output from a single AIRS prompt scan
 // ---------------------------------------------------------------------------
+/** Normalized output from a single AIRS prompt scan. */
 export interface ScanResult {
   scanId: string;
   reportId: string;
   action: 'allow' | 'block';
+  /** Whether the topic guardrail was triggered for this prompt. */
   triggered: boolean;
   category?: string;
   raw?: unknown;
@@ -28,8 +30,12 @@ export interface ScanResult {
 // ---------------------------------------------------------------------------
 // Service interfaces — contracts for scan and topic management adapters
 // ---------------------------------------------------------------------------
+
+/** Contract for AIRS prompt scanning operations. */
 export interface ScanService {
+  /** Scan a single prompt against a security profile. */
   scan(profileName: string, prompt: string, sessionId?: string): Promise<ScanResult>;
+  /** Scan multiple prompts with concurrency control. */
   scanBatch(
     profileName: string,
     prompts: string[],
@@ -38,11 +44,17 @@ export interface ScanService {
   ): Promise<ScanResult[]>;
 }
 
+/** Contract for AIRS topic CRUD and profile linking operations. */
 export interface ManagementService {
+  /** Create a new custom topic. */
   createTopic(request: CreateCustomTopicRequest): Promise<SdkCustomTopic>;
+  /** Update an existing custom topic by ID. */
   updateTopic(topicId: string, request: CreateCustomTopicRequest): Promise<SdkCustomTopic>;
+  /** Delete a custom topic by ID. */
   deleteTopic(topicId: string): Promise<void>;
+  /** List all custom topics. */
   listTopics(): Promise<SdkCustomTopic[]>;
+  /** Assign a topic to a security profile's topic-guardrails. */
   assignTopicToProfile(
     profileName: string,
     topicId: string,

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -25,6 +25,7 @@ import {
   renderTopic,
 } from '../renderer.js';
 
+/** Register the `generate` command — starts a new guardrail generation loop. */
 export function registerGenerateCommand(program: Command): void {
   program
     .command('generate')

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -3,6 +3,7 @@ import { loadConfig } from '../../config/loader.js';
 import { JsonFileStore } from '../../persistence/store.js';
 import { renderError, renderHeader, renderRunList } from '../renderer.js';
 
+/** Register the `list` command — lists all saved runs. */
 export function registerListCommand(program: Command): void {
   program
     .command('list')

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -10,6 +10,7 @@ import {
   renderTopic,
 } from '../renderer.js';
 
+/** Register the `report` command — view detailed results for a run. */
 export function registerReportCommand(program: Command): void {
   program
     .command('report <runId>')

--- a/src/cli/commands/resume.ts
+++ b/src/cli/commands/resume.ts
@@ -18,6 +18,7 @@ import {
   renderTopic,
 } from '../renderer.js';
 
+/** Register the `resume` command — resumes a paused or failed run. */
 export function registerResumeCommand(program: Command): void {
   program
     .command('resume <runId>')

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -2,6 +2,7 @@ import { confirm, input, number, select } from '@inquirer/prompts';
 import type { LlmProvider } from '../config/schema.js';
 import type { UserInput } from '../core/types.js';
 
+/** Interactively collect all user inputs for a generation run via Inquirer prompts. */
 export async function collectUserInput(): Promise<UserInput> {
   const topicDescription = await input({
     message: 'Describe the topic to create a guardrail for:',
@@ -64,6 +65,7 @@ export async function collectUserInput(): Promise<UserInput> {
   };
 }
 
+/** Prompt the user to select an LLM provider from the supported list. */
 export async function selectLlmProvider(): Promise<LlmProvider> {
   return select<LlmProvider>({
     message: 'Select LLM provider:',
@@ -78,6 +80,7 @@ export async function selectLlmProvider(): Promise<LlmProvider> {
   });
 }
 
+/** Prompt the user to confirm whether to continue refining after an iteration. */
 export async function confirmContinue(iteration: number, coverage: number): Promise<boolean> {
   return confirm({
     message: `Iteration ${iteration} complete (coverage: ${(coverage * 100).toFixed(1)}%). Continue refining?`,

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -8,15 +8,18 @@ import type {
 } from '../core/types.js';
 import type { RunStateSummary } from '../persistence/types.js';
 
+/** Render the application banner. */
 export function renderHeader(): void {
   console.log(chalk.bold.cyan('\n  Prisma AIRS Guardrail Generator'));
   console.log(chalk.dim('  Iterative custom topic refinement\n'));
 }
 
+/** Render iteration number header. */
 export function renderIterationStart(iteration: number): void {
   console.log(chalk.bold(`\n━━━ Iteration ${iteration} ━━━`));
 }
 
+/** Render a topic's name, description, and examples. */
 export function renderTopic(topic: CustomTopic): void {
   console.log(chalk.bold('  Topic:'));
   console.log(`    Name: ${chalk.white(topic.name)}`);
@@ -27,6 +30,7 @@ export function renderTopic(topic: CustomTopic): void {
   }
 }
 
+/** Render a scan progress bar with percentage. */
 export function renderTestProgress(completed: number, total: number): void {
   const pct = Math.round((completed / total) * 100);
   const bar = '█'.repeat(Math.round(pct / 5)) + '░'.repeat(20 - Math.round(pct / 5));
@@ -34,6 +38,7 @@ export function renderTestProgress(completed: number, total: number): void {
   if (completed === total) console.log();
 }
 
+/** Render efficacy metrics with color-coded coverage. */
 export function renderMetrics(metrics: EfficacyMetrics): void {
   const coverageColor =
     metrics.coverage >= 0.9 ? chalk.green : metrics.coverage >= 0.7 ? chalk.yellow : chalk.red;
@@ -51,6 +56,7 @@ export function renderMetrics(metrics: EfficacyMetrics): void {
   );
 }
 
+/** Render analysis summary with FP/FN pattern details. */
 export function renderAnalysis(analysis: AnalysisReport): void {
   console.log(chalk.bold('\n  Analysis:'));
   console.log(`    ${analysis.summary}`);
@@ -68,6 +74,7 @@ export function renderAnalysis(analysis: AnalysisReport): void {
   }
 }
 
+/** Render loop completion summary with best iteration and run ID. */
 export function renderLoopComplete(runState: RunState): void {
   const best = runState.iterations[runState.bestIteration - 1];
   console.log(chalk.bold.green('\n━━━ Complete ━━━'));
@@ -81,6 +88,7 @@ export function renderLoopComplete(runState: RunState): void {
   console.log(`\n  Run ID: ${chalk.dim(runState.id)}\n`);
 }
 
+/** Render a list of saved runs with status, coverage, and topic description. */
 export function renderRunList(runs: RunStateSummary[]): void {
   if (runs.length === 0) {
     console.log(chalk.dim('  No saved runs found.\n'));
@@ -105,10 +113,12 @@ export function renderRunList(runs: RunStateSummary[]): void {
   }
 }
 
+/** Render an error message to stderr. */
 export function renderError(message: string): void {
   console.error(chalk.red(`\n  Error: ${message}\n`));
 }
 
+/** Render a one-line iteration summary with duration and coverage. */
 export function renderIterationSummary(result: IterationResult): void {
   const coverageColor =
     result.metrics.coverage >= 0.9
@@ -121,6 +131,7 @@ export function renderIterationSummary(result: IterationResult): void {
   );
 }
 
+/** Render memory loading status (count of learnings loaded or "none found"). */
 export function renderMemoryLoaded(learningCount: number): void {
   if (learningCount > 0) {
     console.log(chalk.cyan(`  Memory: loaded ${learningCount} learnings from previous runs`));
@@ -129,6 +140,7 @@ export function renderMemoryLoaded(learningCount: number): void {
   }
 }
 
+/** Render count of learnings extracted from the current run. */
 export function renderMemoryExtracted(learningCount: number): void {
   console.log(chalk.cyan(`  Memory: extracted ${learningCount} learnings from this run`));
 }

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -14,17 +14,22 @@ import type {
   UserInput,
 } from './types.js';
 
+/** Contract for LLM operations used by the refinement loop. */
 export interface LlmService {
+  /** Generate an initial topic definition from a user description. */
   generateTopic(description: string, intent: string, seeds?: string[]): Promise<CustomTopic>;
+  /** Generate positive and negative test prompts for a topic. */
   generateTests(
     topic: CustomTopic,
     intent: string,
   ): Promise<{ positiveTests: TestCase[]; negativeTests: TestCase[] }>;
+  /** Analyze scan results to identify false positive/negative patterns. */
   analyzeResults(
     topic: CustomTopic,
     results: TestResult[],
     metrics: EfficacyMetrics,
   ): Promise<AnalysisReport>;
+  /** Refine a topic definition based on metrics and analysis from the previous iteration. */
   improveTopic(
     topic: CustomTopic,
     metrics: EfficacyMetrics,
@@ -35,11 +40,17 @@ export interface LlmService {
   ): Promise<CustomTopic>;
 }
 
+/** Dependencies injected into the refinement loop. */
 export interface LoopDependencies {
+  /** LLM service for topic generation, testing, analysis, and improvement. */
   llm: LlmService;
+  /** AIRS management service for topic CRUD and profile linking. */
   management: ManagementService;
+  /** AIRS scan service for batch prompt scanning. */
   scanner: ScanService;
+  /** Delay (ms) after topic deploy to allow AIRS propagation. Default 10000. */
   propagationDelayMs?: number;
+  /** Optional memory system for cross-run learning extraction. */
   memory?: { extractor: LearningExtractor };
 }
 
@@ -47,6 +58,12 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Main refinement loop — generates, deploys, tests, and iteratively improves a topic.
+ * Yields typed {@link LoopEvent} discriminated unions at each stage.
+ * @param input - User input seeding the generation run.
+ * @param deps - Injected service dependencies.
+ */
 export async function* runLoop(
   input: UserInput,
   deps: LoopDependencies,

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -5,6 +5,7 @@ import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { ChatVertexAI } from '@langchain/google-vertexai';
 import type { LlmProvider } from '../config/schema.js';
 
+/** Configuration for creating an LLM provider instance. */
 export interface LlmProviderConfig {
   provider: LlmProvider;
   model?: string;
@@ -26,6 +27,11 @@ const DEFAULT_MODELS: Record<LlmProvider, string> = {
   'gemini-bedrock': 'gemini-2.0-flash',
 };
 
+/**
+ * Factory that creates a LangChain chat model for the configured provider.
+ * @param config - Provider type, model name, and auth credentials.
+ * @returns A configured LangChain BaseChatModel instance.
+ */
 export async function createLlmProvider(config: LlmProviderConfig): Promise<BaseChatModel> {
   const modelName = config.model ?? DEFAULT_MODELS[config.provider];
 

--- a/src/llm/service.ts
+++ b/src/llm/service.ts
@@ -63,6 +63,11 @@ function clampTopic(topic: CustomTopicOutput): CustomTopicOutput {
   return { name, description, examples };
 }
 
+/**
+ * LLM service implementation using LangChain structured output.
+ * Handles topic generation, test creation, result analysis, and topic improvement
+ * with automatic retry and AIRS constraint clamping.
+ */
 export class LangChainLlmService implements LlmService {
   private memorySection = '';
 

--- a/src/memory/injector.ts
+++ b/src/memory/injector.ts
@@ -1,12 +1,26 @@
 import type { MemoryStore } from './store.js';
 import type { Learning } from './types.js';
 
+/**
+ * Builds a budget-aware memory section for LLM prompt injection.
+ * Retrieves relevant learnings from the store, sorts by corroboration count,
+ * and formats them within a character budget (verbose -> compact -> omit).
+ */
 export class MemoryInjector {
+  /**
+   * @param store - Memory store for retrieving learnings.
+   * @param maxChars - Character budget for the memory section. Default 3000.
+   */
   constructor(
     private store: MemoryStore,
     private maxChars: number = 3000,
   ) {}
 
+  /**
+   * Build a formatted memory section string for prompt injection.
+   * @param topicDescription - Topic to find relevant learnings for.
+   * @returns Formatted learnings string, or empty string if none found.
+   */
   async buildMemorySection(topicDescription: string): Promise<string> {
     const memories = await this.store.findRelevant(topicDescription);
     if (memories.length === 0) return '';

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -23,6 +23,12 @@ const STOP_WORDS = new Set([
   'were',
 ]);
 
+/**
+ * Normalize a topic description into a stable category key.
+ * Removes stop words, lowercases, deduplicates, and sorts alphabetically.
+ * @param description - Free-text topic description.
+ * @returns Hyphen-joined keyword string used as the memory file name.
+ */
 export function normalizeCategory(description: string): string {
   const words = description
     .toLowerCase()
@@ -34,6 +40,11 @@ export function normalizeCategory(description: string): string {
   return unique.join('-');
 }
 
+/**
+ * File-based persistence for cross-run learnings.
+ * Stores one JSON file per category at `{dir}/{category}.json`.
+ * Supports keyword-overlap-based retrieval for cross-topic transfer.
+ */
 export class MemoryStore {
   constructor(private dir: string) {}
 
@@ -41,11 +52,13 @@ export class MemoryStore {
     return join(this.dir, `${category}.json`);
   }
 
+  /** Persist a topic memory to disk, creating the directory if needed. */
   async save(memory: TopicMemory): Promise<void> {
     await mkdir(this.dir, { recursive: true });
     await writeFile(this.filePath(memory.category), JSON.stringify(memory, null, 2), 'utf-8');
   }
 
+  /** Load a topic memory by category, or null if not found. */
   async load(category: string): Promise<TopicMemory | null> {
     try {
       const data = await readFile(this.filePath(category), 'utf-8');
@@ -55,6 +68,7 @@ export class MemoryStore {
     }
   }
 
+  /** Find all topic memories with >= 50% keyword overlap to the given description. */
   async findRelevant(topicDescription: string): Promise<TopicMemory[]> {
     const targetCategory = normalizeCategory(topicDescription);
     const categories = await this.listCategories();
@@ -70,6 +84,7 @@ export class MemoryStore {
     return results;
   }
 
+  /** List all stored category names. */
   async listCategories(): Promise<string[]> {
     try {
       const files = await readdir(this.dir);

--- a/src/persistence/store.ts
+++ b/src/persistence/store.ts
@@ -3,9 +3,15 @@ import { join } from 'node:path';
 import type { RunState } from '../core/types.js';
 import type { RunStateSummary, RunStore } from './types.js';
 
+/**
+ * JSON file-based run state persistence.
+ * Stores one file per run at `{dir}/{runId}.json` with atomic writes.
+ */
 export class JsonFileStore implements RunStore {
+  /** @param dir - Directory for run state JSON files. */
   constructor(private readonly dir: string) {}
 
+  /** Save a run state to disk, creating the directory if needed. */
   async save(run: RunState): Promise<void> {
     await mkdir(this.dir, { recursive: true });
     const filePath = this.filePath(run.id);
@@ -15,6 +21,7 @@ export class JsonFileStore implements RunStore {
     await unlink(tmp).catch(() => {});
   }
 
+  /** Load a run state by ID, or null if not found. */
   async load(id: string): Promise<RunState | null> {
     try {
       const data = await readFile(this.filePath(id), 'utf-8');
@@ -24,6 +31,7 @@ export class JsonFileStore implements RunStore {
     }
   }
 
+  /** List summaries of all persisted runs. */
   async list(): Promise<RunStateSummary[]> {
     let files: string[];
     try {
@@ -54,6 +62,7 @@ export class JsonFileStore implements RunStore {
     return summaries;
   }
 
+  /** Delete a run state by ID. No-op if it doesn't exist. */
   async delete(id: string): Promise<void> {
     try {
       await unlink(this.filePath(id));

--- a/src/persistence/types.ts
+++ b/src/persistence/types.ts
@@ -1,12 +1,18 @@
 import type { RunState } from '../core/types.js';
 
+/** Contract for run state persistence backends. */
 export interface RunStore {
+  /** Save or overwrite a run state. */
   save(run: RunState): Promise<void>;
+  /** Load a run state by ID, or null if not found. */
   load(id: string): Promise<RunState | null>;
+  /** List summaries of all persisted runs. */
   list(): Promise<RunStateSummary[]>;
+  /** Delete a run state by ID. */
   delete(id: string): Promise<void>;
 }
 
+/** Lightweight summary of a persisted run for listing. */
 export interface RunStateSummary {
   id: string;
   createdAt: string;


### PR DESCRIPTION
## Summary
Add JSDoc/TSDoc to all 36+ exported symbols that were missing documentation:

**High priority (core interfaces):**
- `LlmService` interface — all 4 method signatures
- `LoopDependencies` interface — all fields
- `runLoop()` async generator
- `ScanService` / `ManagementService` interfaces — all methods
- `LlmProviderConfig` / `createLlmProvider()`
- `LangChainLlmService` class

**Medium priority (memory/persistence):**
- `MemoryStore` — class + all public methods
- `normalizeCategory()`
- `MemoryInjector` — class + `buildMemorySection()`
- `JsonFileStore` — class + all CRUD methods
- `RunStore` / `RunStateSummary` interfaces

**Low priority (CLI):**
- All 12 renderer functions
- 3 prompt functions
- 4 command registration functions

Closes #16

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm test` — 195/195 pass
- [ ] CI actions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)