### PR TITLE
docs: sync remaining docs with v1.0.7 changes

### DIFF
--- a/docs/architecture/design-decisions.md
+++ b/docs/architecture/design-decisions.md
@@ -100,14 +100,20 @@ const chain = llm.withStructuredOutput(TopicSchema, {
 
 ## 8. Event-Driven Architecture
 
-The loop emits 11 distinct event types covering the full lifecycle:
+The `LoopEvent` union defines 11 event types. Of these, 9 are yielded by `runLoop()`:
 
 | Phase | Events |
 |-------|--------|
-| Setup | `memory:loaded` |
 | Per-iteration | `iteration:start`, `generate:complete`, `apply:complete`, `test:progress`, `evaluate:complete`, `analyze:complete`, `iteration:complete` |
-| Terminal | `loop:complete`, `loop:paused` |
-| Teardown | `memory:extracted` |
+| Post-loop | `memory:extracted` (if memory enabled) |
+| Terminal | `loop:complete` |
+
+Two events are defined in the type union but not yielded by the loop:
+
+| Event | Status |
+|-------|--------|
+| `memory:loaded` | Emitted by CLI command before the loop starts |
+| `loop:paused` | Reserved for future use |
 
 **Rationale:** Fine-grained events enable rich progress reporting (the CLI shows per-test scan progress), clean separation of concerns (renderer knows nothing about LLM calls), and future extensibility (logging, metrics dashboards, web UIs) without modifying the core loop.
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -45,6 +45,7 @@ pnpm run format     # Format all files
     All of the following must pass before merge:
 
     - Biome lint (`pnpm run lint`)
+    - Biome format check (`pnpm run format:check`)
     - TypeScript type-check (`pnpm tsc --noEmit`)
     - Full test suite (`pnpm test`)
     - Docs build (if docs changed)

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -47,6 +47,7 @@ Edit `.env` with your credentials:
 | `pnpm run lint` | Biome lint check |
 | `pnpm run lint:fix` | Auto-fix lint issues |
 | `pnpm run format` | Format with Biome |
+| `pnpm run format:check` | Check formatting (no write) |
 | `pnpm tsc --noEmit` | Type-check |
 
 ## Data Directories


### PR DESCRIPTION
## Summary
Catch-up docs sync for changes that landed in v1.0.7 but were missed in secondary docs pages:

- **`docs/architecture/design-decisions.md`**: Fix event table — `memory:loaded` is not yielded by the loop, `loop:paused` is reserved for future use (mirrors fix from #13)
- **`docs/development/contributing.md`**: Add `format:check` to CI requirements (mirrors #12)
- **`docs/development/local-setup.md`**: Add `format:check` to dev commands table (mirrors #12)

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm test` — 195/195 pass
- [ ] CI + docs build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)