### PR TITLE
fix: allow-intent detection via category field

### DIFF
--- a/.changeset/0000-fix-allow-intent-detection.md
+++ b/.changeset/0000-fix-allow-intent-detection.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/daystrom": patch
+---
+
+Fix allow-intent detection: use `category` field (`benign`/`malicious`) instead of broken `action === 'allow'` heuristic. Fix profile guardrail-level action to always be `block`. Add `--debug-scans` flag for raw AIRS response inspection.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,9 @@ tests/
 - Stop: `coverage >= targetCoverage` (default 0.9). Coverage = `min(TPR, TNR)`
 
 ### AIRS Integration (`src/airs/`)
-- **Scanner**: `Scanner.syncScan()` via SDK, detection = `prompt_detected.topic_violation` (fallback: `topic_guardrails_details`)
-- **Allow-intent signal inversion**: For allow topics, AIRS never sets `triggered: true` — the loop derives `actualTriggered` from `action === 'allow'` instead
+- **Scanner**: `Scanner.syncScan()` via SDK, detection = `prompt_detected.topic_violation` (fallback: `topic_guardrails_details`), extracts `category` from response
+- **Allow-intent detection via `category`**: For allow topics, AIRS never sets `triggered: true` and `action` is unreliable. The loop uses `category === 'benign'` (topic matched) vs `'malicious'` (no match), falling back to `triggered` when `category` is absent
+- **`DebugScanService`**: Wrapper that appends raw scan responses to a JSONL file when `--debug-scans` is passed
 - **Management**: `ManagementClient` for topic CRUD + profile linking via OAuth2
 - Profile updates create **new revisions with new UUIDs** — always reference profiles by name, never ID
 - Topics must be added to profile's `model-protection` → `topic-guardrails` → `topic-list`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cd daystrom
 pnpm install
 cp .env.example .env   # edit with your credentials
 pnpm run generate      # run via tsx
-pnpm test              # 192 tests
+pnpm test              # 217 tests
 pnpm run lint          # biome check
 ```
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## v1.1.1
+
+### Bug Fixes
+
+- **Fix allow-intent detection (P0)**: The v1.1.0 `action === 'allow'` heuristic was wrong — AIRS returns `action: 'allow'` for all prompts on allow topics. Detection now uses the `category` field (`'benign'` = topic matched, `'malicious'` = no match), with fallback to `triggered` when `category` is absent.
+- **Fix profile guardrail-level action**: `topic-guardrails` entry in security profiles now always uses `action: 'block'` to enforce violations. Previously defaulted to `'allow'`, causing all topic guardrails to be unenforced.
+
+### Features
+
+- **`--debug-scans` flag**: Dumps raw AIRS scan responses to a JSONL file (`~/.daystrom/debug-scans-*.jsonl`) for offline inspection. Available on both `generate` and `resume` commands.
+- **Scanner extracts `category`**: The `category` field from AIRS responses is now included in `ScanResult`.
+
+### Tests
+
+- 217 tests across 17 spec files (up from 209)
+
 ## v1.1.0
 
 ### Bug Fixes

--- a/docs/architecture/design-decisions.md
+++ b/docs/architecture/design-decisions.md
@@ -130,18 +130,18 @@ The `analyzeResults()` and `improveTopic()` LLM calls receive the guardrail inte
 
 Without intent context, the LLM defaults to block-style refinement (catch more), which actively harms allow guardrails by making them over-trigger.
 
-### Allow-Intent Signal Inversion
+### Allow-Intent Detection via `category`
 
 AIRS reports topic detection differently for allow vs block intent:
 
-| Intent | Prompt matches topic | `triggered` | `action` |
-|--------|---------------------|-------------|----------|
-| Block | Yes (violating content) | `true` | `block` |
-| Block | No (benign content) | `false` | `allow` |
-| Allow | Yes (permitted content) | `false` | `allow` |
-| Allow | No (non-permitted content) | `false` | `block` |
+| Intent | Prompt matches topic | `triggered` | `category` |
+|--------|---------------------|-------------|------------|
+| Block | Yes (violating content) | `true` | `malicious` |
+| Block | No (benign content) | `false` | `benign` |
+| Allow | Yes (permitted content) | `false` | `benign` |
+| Allow | No (non-permitted content) | `false` | `malicious` |
 
-For allow intent, `triggered` is never `true` — AIRS uses the `action` field to signal whether content matched. The loop derives `actualTriggered` from `action === 'allow'` for allow intent, and from `triggered` for block intent.
+For allow intent, `triggered` is never `true`. The `action` field is also unreliable (always `allow`). The `category` field is the correct discriminator: `"benign"` means the content matched the allow topic, `"malicious"` means it did not. The loop uses `category === 'benign'` for allow-intent detection, falling back to `triggered` when `category` is absent.
 
 ### Variable Example Count (2-5)
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -28,6 +28,7 @@ daystrom generate [options]
 | `--accumulate-tests` | off | Carry forward test prompts across iterations |
 | `--max-accumulated-tests <n>` | unlimited | Cap on accumulated test count |
 | `--no-memory` | memory on | Disable cross-run learning |
+| `--debug-scans` | off | Dump raw AIRS scan responses to JSONL for debugging |
 
 !!! tip "Skip all prompts"
     When both `--topic` and `--profile` are provided, interactive mode is skipped entirely.
@@ -81,6 +82,7 @@ daystrom resume <runId> [options]
 | Flag | Default | What it does |
 |------|---------|-------------|
 | `--max-iterations <n>` | `20` | Additional iterations from current position |
+| `--debug-scans` | off | Dump raw AIRS scan responses to JSONL for debugging |
 
 ```bash
 daystrom resume abc123xyz --max-iterations 10

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Automated Prisma AIRS custom topic guardrail generator with iterative refinement",
   "type": "module",
   "main": "dist/index.js",

--- a/src/airs/management.ts
+++ b/src/airs/management.ts
@@ -65,13 +65,17 @@ export class SdkManagementService implements ManagementService {
 
     if (!topicGuardrails) {
       topicGuardrails = {
-        action: 'allow',
+        action: 'block',
         name: 'topic-guardrails',
         options: [],
         'topic-list': [],
       };
       modelProtection.push(topicGuardrails);
     }
+
+    // Ensure the guardrail-level action is always 'block' so violations are enforced.
+    // The allow/block distinction is controlled by which topic-list entry the topic is in.
+    topicGuardrails.action = 'block';
 
     // Replace the entire topic-list with only the current topic under the given action.
     // The opposite action gets an empty list to ensure no stale topics remain.

--- a/src/airs/scanner.ts
+++ b/src/airs/scanner.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs/promises';
 import { Content, init, Scanner } from '@cdot65/prisma-airs-sdk';
 import pLimit from 'p-limit';
 import type { ScanResult, ScanService } from './types.js';
@@ -21,12 +22,14 @@ export class AirsScanService implements ScanService {
     const action = response.action === 'block' ? 'block' : 'allow';
     const detected = response.prompt_detected as Record<string, unknown> | undefined;
     const triggered = !!(detected?.topic_guardrails_details || detected?.topic_violation);
+    const category = (response.category as string) ?? undefined;
 
     return {
       scanId: response.scan_id ?? '',
       reportId: response.report_id ?? '',
       action: action as 'allow' | 'block',
       triggered,
+      category,
       raw: response,
     };
   }
@@ -38,6 +41,42 @@ export class AirsScanService implements ScanService {
     sessionId?: string,
   ): Promise<ScanResult[]> {
     const limit = pLimit(concurrency);
+    return Promise.all(
+      prompts.map((prompt) => limit(() => this.scan(profileName, prompt, sessionId))),
+    );
+  }
+}
+
+/**
+ * Debug wrapper that delegates to an inner ScanService and appends
+ * each raw response + prompt to a JSONL file for offline inspection.
+ */
+export class DebugScanService implements ScanService {
+  constructor(
+    private inner: ScanService,
+    private filePath: string,
+  ) {}
+
+  async scan(profileName: string, prompt: string, sessionId?: string): Promise<ScanResult> {
+    const result = await this.inner.scan(profileName, prompt, sessionId);
+    const entry = JSON.stringify({
+      prompt,
+      profileName,
+      result,
+      raw: result.raw,
+      timestamp: Date.now(),
+    });
+    await fs.appendFile(this.filePath, `${entry}\n`);
+    return result;
+  }
+
+  async scanBatch(
+    profileName: string,
+    prompts: string[],
+    concurrency?: number,
+    sessionId?: string,
+  ): Promise<ScanResult[]> {
+    const limit = pLimit(concurrency ?? 5);
     return Promise.all(
       prompts.map((prompt) => limit(() => this.scan(profileName, prompt, sessionId))),
     );

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -1,6 +1,8 @@
+import * as path from 'node:path';
 import type { Command } from 'commander';
 import { SdkManagementService } from '../../airs/management.js';
-import { AirsScanService } from '../../airs/scanner.js';
+import { AirsScanService, DebugScanService } from '../../airs/scanner.js';
+import type { ScanService } from '../../airs/types.js';
 import { loadConfig } from '../../config/loader.js';
 import { runLoop } from '../../core/loop.js';
 import type { UserInput } from '../../core/types.js';
@@ -42,6 +44,7 @@ export function registerGenerateCommand(program: Command): void {
     .option('--max-accumulated-tests <n>', 'Max accumulated test count cap')
     .option('--memory', 'Enable learning memory (default)')
     .option('--no-memory', 'Disable learning memory')
+    .option('--debug-scans', 'Dump raw AIRS scan responses to JSONL for debugging', false)
     .action(async (opts) => {
       try {
         renderHeader();
@@ -92,7 +95,11 @@ export function registerGenerateCommand(program: Command): void {
 
         const llm = new LangChainLlmService(model, memoryInjector);
         if (!config.airsApiKey) throw new Error('PANW_AI_SEC_API_KEY is required');
-        const scanner = new AirsScanService(config.airsApiKey);
+        let scanner: ScanService = new AirsScanService(config.airsApiKey);
+        if (opts.debugScans) {
+          const debugPath = path.join(config.dataDir, '..', `debug-scans-${Date.now()}.jsonl`);
+          scanner = new DebugScanService(scanner, debugPath);
+        }
         const management = new SdkManagementService({
           clientId: config.mgmtClientId,
           clientSecret: config.mgmtClientSecret,

--- a/src/cli/commands/resume.ts
+++ b/src/cli/commands/resume.ts
@@ -1,6 +1,8 @@
+import * as path from 'node:path';
 import type { Command } from 'commander';
 import { SdkManagementService } from '../../airs/management.js';
-import { AirsScanService } from '../../airs/scanner.js';
+import { AirsScanService, DebugScanService } from '../../airs/scanner.js';
+import type { ScanService } from '../../airs/types.js';
 import { loadConfig } from '../../config/loader.js';
 import { runLoop } from '../../core/loop.js';
 import { createLlmProvider } from '../../llm/provider.js';
@@ -25,6 +27,7 @@ export function registerResumeCommand(program: Command): void {
     .command('resume <runId>')
     .description('Resume a paused or failed run')
     .option('--max-iterations <n>', 'Additional iterations to run', '10')
+    .option('--debug-scans', 'Dump raw AIRS scan responses to JSONL for debugging', false)
     .action(async (runId: string, opts) => {
       try {
         renderHeader();
@@ -64,7 +67,11 @@ export function registerResumeCommand(program: Command): void {
 
         const llm = new LangChainLlmService(model);
         if (!config.airsApiKey) throw new Error('PANW_AI_SEC_API_KEY is required');
-        const scanner = new AirsScanService(config.airsApiKey);
+        let scanner: ScanService = new AirsScanService(config.airsApiKey);
+        if (opts.debugScans) {
+          const debugPath = path.join(config.dataDir, '..', `debug-scans-${runId}.jsonl`);
+          scanner = new DebugScanService(scanner, debugPath);
+        }
         const management = new SdkManagementService({
           clientId: config.mgmtClientId,
           clientSecret: config.mgmtClientSecret,

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -225,11 +225,16 @@ export async function* runLoop(
     for (let j = 0; j < allTests.length; j++) {
       const testCase = allTests[j];
       const scanResult = scanResults[j];
-      // For block intent: "triggered" means topic violation detected (matched blocked content).
-      // For allow intent: AIRS inverts the signal — matching allowed content yields action "allow"
-      // (no violation), so we derive "triggered" from the action field instead.
-      const actualTriggered =
-        input.intent === 'allow' ? scanResult.action === 'allow' : scanResult.triggered;
+      // Derive whether the topic guardrail matched this prompt.
+      // For allow intent: AIRS never sets triggered=true; use category field instead
+      // ("benign" = matched the allow topic, "malicious" = did not match).
+      // For block intent: use the triggered flag directly.
+      let actualTriggered: boolean;
+      if (input.intent === 'allow' && scanResult.category) {
+        actualTriggered = scanResult.category === 'benign';
+      } else {
+        actualTriggered = scanResult.triggered;
+      }
       testResults.push({
         testCase,
         actualTriggered,

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -71,6 +71,7 @@ export function createMockScanService(
         reportId: `report-${Date.now()}`,
         action: triggered ? 'block' : 'allow',
         triggered,
+        category: triggered ? 'malicious' : 'benign',
       };
     },
     scanBatch: async (
@@ -87,6 +88,7 @@ export function createMockScanService(
           reportId: `report-${Date.now()}`,
           action: triggered ? 'block' : 'allow',
           triggered,
+          category: triggered ? 'malicious' : 'benign',
         });
       }
       return results;
@@ -96,8 +98,9 @@ export function createMockScanService(
 
 /**
  * Mock scanner simulating AIRS allow-intent behavior.
- * Matching prompts → action: 'allow', triggered: false (no violation).
- * Non-matching prompts → action: 'block', triggered: false (blocked, no topic_violation).
+ * Matching prompts → category: 'benign' (content matched the allow topic).
+ * Non-matching prompts → category: 'malicious' (content not in allowed set).
+ * triggered is always false for allow topics; action is always 'allow'.
  */
 export function createMockAllowScanService(allowPatterns: RegExp[] = []): ScanService {
   return {
@@ -106,8 +109,9 @@ export function createMockAllowScanService(allowPatterns: RegExp[] = []): ScanSe
       return {
         scanId: `scan-${Date.now()}`,
         reportId: `report-${Date.now()}`,
-        action: matches ? 'allow' : 'block',
+        action: 'allow',
         triggered: false, // AIRS never sets topic_violation for allow-intent topics
+        category: matches ? 'benign' : 'malicious',
       };
     },
     scanBatch: async (
@@ -122,8 +126,9 @@ export function createMockAllowScanService(allowPatterns: RegExp[] = []): ScanSe
         results.push({
           scanId: `scan-${Date.now()}`,
           reportId: `report-${Date.now()}`,
-          action: matches ? 'allow' : 'block',
+          action: 'allow',
           triggered: false,
+          category: matches ? 'benign' : 'malicious',
         });
       }
       return results;

--- a/tests/unit/airs/management.spec.ts
+++ b/tests/unit/airs/management.spec.ts
@@ -381,5 +381,55 @@ describe('SdkManagementService', () => {
       const blockEntry = tg['topic-list'].find((tl) => tl.action === 'block');
       expect(blockEntry?.topic).toEqual([]);
     });
+
+    it('always sets guardrail-level action to block', async () => {
+      // Even when existing guardrail has action: 'allow', it should be overwritten to 'block'
+      mockProfileList.mockResolvedValue({
+        ai_profiles: [
+          {
+            profile_id: 'p-1',
+            profile_name: 'test-profile',
+            active: true,
+            policy: {
+              'ai-security-profiles': [
+                {
+                  'model-type': 'default',
+                  'model-configuration': {
+                    'model-protection': [
+                      {
+                        name: 'topic-guardrails',
+                        action: 'allow',
+                        options: [],
+                        'topic-list': [],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      mockProfileUpdate.mockResolvedValue({});
+
+      await service.assignTopicToProfile('test-profile', 'topic-1', 'Weapons', 'block');
+
+      const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
+      expect((tg as Record<string, unknown>).action).toBe('block');
+    });
+
+    it('sets guardrail-level action to block even for allow-intent topics', async () => {
+      mockProfileList.mockResolvedValue({
+        ai_profiles: [
+          { profile_id: 'p-1', profile_name: 'test-profile', active: true, policy: {} },
+        ],
+      });
+      mockProfileUpdate.mockResolvedValue({});
+
+      await service.assignTopicToProfile('test-profile', 'topic-1', 'Safe Topic', 'allow');
+
+      const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
+      expect((tg as Record<string, unknown>).action).toBe('block');
+    });
   });
 });

--- a/tests/unit/airs/scanner.spec.ts
+++ b/tests/unit/airs/scanner.spec.ts
@@ -1,5 +1,9 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AirsScanService } from '../../../src/airs/scanner.js';
+import { AirsScanService, DebugScanService } from '../../../src/airs/scanner.js';
+import type { ScanResult, ScanService } from '../../../src/airs/types.js';
 
 // Mock the SDK
 const mockSyncScan = vi.fn();
@@ -106,6 +110,31 @@ describe('AirsScanService', () => {
         { sessionId: 'daystrom-abc1234-iter1' },
       );
     });
+
+    it('extracts category from response', async () => {
+      mockSyncScan.mockResolvedValue({
+        scan_id: 's1',
+        report_id: 'r1',
+        action: 'allow',
+        category: 'benign',
+        prompt_detected: {},
+      });
+
+      const result = await service.scan('prof', 'hello');
+      expect(result.category).toBe('benign');
+    });
+
+    it('returns undefined category when not in response', async () => {
+      mockSyncScan.mockResolvedValue({
+        scan_id: 's1',
+        report_id: 'r1',
+        action: 'allow',
+        prompt_detected: {},
+      });
+
+      const result = await service.scan('prof', 'hello');
+      expect(result.category).toBeUndefined();
+    });
   });
 
   describe('scanBatch', () => {
@@ -146,5 +175,81 @@ describe('AirsScanService', () => {
       await service.scanBatch('profile', prompts, 3);
       expect(maxConcurrent).toBeLessThanOrEqual(3);
     });
+  });
+});
+
+describe('DebugScanService', () => {
+  function createMockInner(): ScanService {
+    return {
+      scan: async (): Promise<ScanResult> => ({
+        scanId: 'scan-1',
+        reportId: 'report-1',
+        action: 'allow',
+        triggered: false,
+        category: 'benign',
+        raw: { some: 'data' },
+      }),
+      scanBatch: async (_p: string, prompts: string[]): Promise<ScanResult[]> =>
+        prompts.map(() => ({
+          scanId: 'scan-1',
+          reportId: 'report-1',
+          action: 'allow' as const,
+          triggered: false,
+          category: 'benign',
+          raw: { some: 'data' },
+        })),
+    };
+  }
+
+  it('delegates to inner scanner and returns result', async () => {
+    const tmpFile = path.join(os.tmpdir(), `debug-test-${Date.now()}.jsonl`);
+    const inner = createMockInner();
+    const debug = new DebugScanService(inner, tmpFile);
+
+    const result = await debug.scan('profile', 'hello');
+    expect(result.scanId).toBe('scan-1');
+    expect(result.category).toBe('benign');
+
+    // Clean up
+    await fs.unlink(tmpFile).catch(() => {});
+  });
+
+  it('writes JSONL entries to file', async () => {
+    const tmpFile = path.join(os.tmpdir(), `debug-test-${Date.now()}.jsonl`);
+    const inner = createMockInner();
+    const debug = new DebugScanService(inner, tmpFile);
+
+    await debug.scan('profile', 'prompt one');
+    await debug.scan('profile', 'prompt two');
+
+    const content = await fs.readFile(tmpFile, 'utf-8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(2);
+
+    const entry1 = JSON.parse(lines[0]);
+    expect(entry1.prompt).toBe('prompt one');
+    expect(entry1.profileName).toBe('profile');
+    expect(entry1.result).toBeDefined();
+    expect(entry1.timestamp).toBeTypeOf('number');
+
+    const entry2 = JSON.parse(lines[1]);
+    expect(entry2.prompt).toBe('prompt two');
+
+    await fs.unlink(tmpFile).catch(() => {});
+  });
+
+  it('scanBatch delegates through scan and writes entries', async () => {
+    const tmpFile = path.join(os.tmpdir(), `debug-test-${Date.now()}.jsonl`);
+    const inner = createMockInner();
+    const debug = new DebugScanService(inner, tmpFile);
+
+    const results = await debug.scanBatch('profile', ['a', 'b', 'c']);
+    expect(results).toHaveLength(3);
+
+    const content = await fs.readFile(tmpFile, 'utf-8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(3);
+
+    await fs.unlink(tmpFile).catch(() => {});
   });
 });

--- a/tests/unit/core/loop.spec.ts
+++ b/tests/unit/core/loop.spec.ts
@@ -383,8 +383,8 @@ describe('runLoop', () => {
     );
   });
 
-  it('uses action field for allow-intent triggered detection', async () => {
-    // Mock scanner simulating AIRS allow-intent: matching prompts → action: 'allow'
+  it('uses category field for allow-intent triggered detection', async () => {
+    // Mock scanner simulating AIRS allow-intent: matching prompts → category: 'benign'
     const allowScanner = createMockAllowScanService([/weapon/i, /bomb/i]);
     const llm = createMockLlm();
     const deps = createDeps({ llm, scanner: allowScanner });
@@ -400,11 +400,45 @@ describe('runLoop', () => {
     const evalEvent = events.find((e) => e.type === 'evaluate:complete');
     expect(evalEvent).toBeDefined();
     if (evalEvent?.type === 'evaluate:complete') {
-      // "weapon" and "bomb" prompts should now be detected as matching (action: 'allow')
-      // "cats" and "weather" should NOT match (action: 'block')
-      // With allow intent, actualTriggered = (action === 'allow')
+      // "weapon" and "bomb" prompts → category: 'benign' → actualTriggered = true
+      // "cats" and "weather" → category: 'malicious' → actualTriggered = false
       expect(evalEvent.metrics.truePositives).toBeGreaterThan(0);
       expect(evalEvent.metrics.trueNegatives).toBeGreaterThan(0);
+    }
+  });
+
+  it('falls back to triggered when category absent for allow-intent', async () => {
+    // Scanner with no category field — should fall back to triggered
+    const noCategoryScanner: import('../../../src/airs/types.js').ScanService = {
+      scan: async () => ({
+        scanId: 's1',
+        reportId: 'r1',
+        action: 'allow' as const,
+        triggered: false,
+      }),
+      scanBatch: async (_p, prompts) =>
+        prompts.map(() => ({
+          scanId: 's1',
+          reportId: 'r1',
+          action: 'allow' as const,
+          triggered: false,
+        })),
+    };
+    const deps = createDeps({ scanner: noCategoryScanner });
+    const events: LoopEvent[] = [];
+
+    for await (const event of runLoop(
+      { ...defaultInput, intent: 'allow', maxIterations: 1 },
+      deps,
+    )) {
+      events.push(event);
+    }
+
+    const evalEvent = events.find((e) => e.type === 'evaluate:complete');
+    expect(evalEvent).toBeDefined();
+    if (evalEvent?.type === 'evaluate:complete') {
+      // All triggered=false, so all actualTriggered=false → positive tests are FN
+      expect(evalEvent.metrics.falseNegatives).toBeGreaterThan(0);
     }
   });
 


### PR DESCRIPTION
## Summary

- **Fix allow-intent detection (P0)**: v1.1.0's `action === 'allow'` heuristic was wrong — AIRS returns `action: 'allow'` for ALL prompts on allow topics. Now uses `category` field (`'benign'` = topic matched, `'malicious'` = no match) with fallback to `triggered` when absent
- **Fix profile guardrail-level action**: `topic-guardrails` entry now always uses `action: 'block'` to enforce violations (was `'allow'`, causing all topic guardrails to be unenforced)
- **Add `--debug-scans` CLI flag**: Dumps raw AIRS scan responses to JSONL for offline inspection (generate + resume commands)
- **Version bump**: 1.1.0 → 1.1.1

## Files changed

| Area | Files |
|------|-------|
| Core fix | `src/core/loop.ts`, `src/airs/scanner.ts`, `src/airs/management.ts` |
| CLI | `src/cli/commands/generate.ts`, `src/cli/commands/resume.ts` |
| Tests | `tests/unit/airs/scanner.spec.ts`, `tests/unit/core/loop.spec.ts`, `tests/unit/airs/management.spec.ts`, `tests/helpers/mocks.ts` |
| Docs | `CLAUDE.md`, `README.md`, `docs/architecture/design-decisions.md`, `docs/reference/cli-commands.md`, `docs/about/release-notes.md` |

## Test plan

- [x] 217 tests pass (up from 209)
- [x] 99.91% statement coverage, 100% function coverage
- [x] Type-check clean
- [x] Lint + format clean
- [ ] CI passes (lint, typecheck, test, docs-build)
- [ ] Manual e2e against real AIRS with `--debug-scans` to verify category field

🤖 Generated with [Claude Code](https://claude.com/claude-code)