### PR TITLE
fix: profile topic-list payload rejects empty entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,8 @@ tests/
 - **Management**: `ManagementClient` for topic CRUD + profile linking via OAuth2
 - Profile updates create **new revisions with new UUIDs** — always reference profiles by name, never ID
 - Topics must be added to profile's `model-protection` → `topic-guardrails` → `topic-list`
+- AIRS rejects empty `topic-list` entries — only include entries with topics (no empty opposite-action entry)
+- Guardrail-level `action` must always be `'block'` to enforce violations
 - Topics can't be deleted while referenced by any profile revision
 
 ### LLM Service (`src/llm/`)

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v1.1.2
+
+### Bug Fixes
+
+- **Fix profile topic-list payload**: AIRS rejects empty `topic-list` entries. The `assignTopicToProfile` method was sending two entries (one for the action, one empty for the opposite), causing a 400 error on profile update. Now sends a single entry containing only the active topic. Also removed unnecessary `revision` field from topic entries.
+
 ## v1.1.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Automated Prisma AIRS custom topic guardrail generator with iterative refinement",
   "type": "module",
   "main": "dist/index.js",

--- a/src/airs/management.ts
+++ b/src/airs/management.ts
@@ -78,16 +78,11 @@ export class SdkManagementService implements ManagementService {
     topicGuardrails.action = 'block';
 
     // Replace the entire topic-list with only the current topic under the given action.
-    // The opposite action gets an empty list to ensure no stale topics remain.
-    const oppositeAction = action === 'block' ? 'allow' : 'block';
+    // AIRS rejects empty topic-list entries, so only include the entry with the topic.
     topicGuardrails['topic-list'] = [
       {
         action,
-        topic: [{ topic_id: topicId, topic_name: topicName, revision: 1 }],
-      },
-      {
-        action: oppositeAction,
-        topic: [],
+        topic: [{ topic_id: topicId, topic_name: topicName }],
       },
     ];
 

--- a/tests/unit/airs/management.spec.ts
+++ b/tests/unit/airs/management.spec.ts
@@ -4,7 +4,6 @@ import { SdkManagementService } from '../../../src/airs/management.js';
 interface PolicyTopicEntry {
   topic_id: string;
   topic_name: string;
-  revision: number;
 }
 interface PolicyActionEntry {
   action: string;
@@ -175,13 +174,10 @@ describe('SdkManagementService', () => {
       );
 
       const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
+      // Only a single topic-list entry for the action (no empty opposite entry)
+      expect(tg['topic-list']).toHaveLength(1);
       const blockEntry = tg['topic-list'].find((tl) => tl.action === 'block');
-      expect(blockEntry?.topic).toEqual([
-        { topic_id: 'topic-1', topic_name: 'Weapons', revision: 1 },
-      ]);
-      // Opposite action should be empty
-      const allowEntry = tg['topic-list'].find((tl) => tl.action === 'allow');
-      expect(allowEntry?.topic).toEqual([]);
+      expect(blockEntry?.topic).toEqual([{ topic_id: 'topic-1', topic_name: 'Weapons' }]);
     });
 
     it('handles profile with no policy (undefined)', async () => {
@@ -240,9 +236,9 @@ describe('SdkManagementService', () => {
                           {
                             action: 'block',
                             topic: [
-                              { topic_id: 'stale-1', topic_name: 'Old Run 1', revision: 1 },
-                              { topic_id: 'stale-2', topic_name: 'Old Run 2', revision: 1 },
-                              { topic_id: 'stale-3', topic_name: 'Old Run 3', revision: 1 },
+                              { topic_id: 'stale-1', topic_name: 'Old Run 1' },
+                              { topic_id: 'stale-2', topic_name: 'Old Run 2' },
+                              { topic_id: 'stale-3', topic_name: 'Old Run 3' },
                             ],
                           },
                           { action: 'allow', topic: [] },
@@ -263,9 +259,7 @@ describe('SdkManagementService', () => {
       const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
       const blockEntry = tg['topic-list'].find((tl) => tl.action === 'block');
       // Only the current topic — stale ones removed
-      expect(blockEntry?.topic).toEqual([
-        { topic_id: 'topic-new', topic_name: 'Current Run', revision: 1 },
-      ]);
+      expect(blockEntry?.topic).toEqual([{ topic_id: 'topic-new', topic_name: 'Current Run' }]);
     });
 
     it('always updates even when same topic already linked', async () => {
@@ -289,8 +283,8 @@ describe('SdkManagementService', () => {
                           {
                             action: 'block',
                             topic: [
-                              { topic_id: 'topic-1', topic_name: 'Weapons', revision: 1 },
-                              { topic_id: 'stale', topic_name: 'Stale', revision: 1 },
+                              { topic_id: 'topic-1', topic_name: 'Weapons' },
+                              { topic_id: 'stale', topic_name: 'Stale' },
                             ],
                           },
                         ],
@@ -315,7 +309,7 @@ describe('SdkManagementService', () => {
       expect(blockEntry?.topic[0].topic_id).toBe('topic-1');
     });
 
-    it('clears opposite action list', async () => {
+    it('replaces all existing topic-list entries with single current action', async () => {
       mockProfileList.mockResolvedValue({
         ai_profiles: [
           {
@@ -335,11 +329,11 @@ describe('SdkManagementService', () => {
                         'topic-list': [
                           {
                             action: 'allow',
-                            topic: [{ topic_id: 'old-allow', topic_name: 'Old', revision: 1 }],
+                            topic: [{ topic_id: 'old-allow', topic_name: 'Old' }],
                           },
                           {
                             action: 'block',
-                            topic: [{ topic_id: 'old-block', topic_name: 'Old', revision: 1 }],
+                            topic: [{ topic_id: 'old-block', topic_name: 'Old' }],
                           },
                         ],
                       },
@@ -356,10 +350,10 @@ describe('SdkManagementService', () => {
       await service.assignTopicToProfile('test-profile', 'topic-1', 'Weapons', 'block');
 
       const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
-      const allowEntry = tg['topic-list'].find((tl) => tl.action === 'allow');
-      expect(allowEntry?.topic).toEqual([]);
-      const blockEntry = tg['topic-list'].find((tl) => tl.action === 'block');
-      expect(blockEntry?.topic).toHaveLength(1);
+      // Only one entry — the current action
+      expect(tg['topic-list']).toHaveLength(1);
+      expect(tg['topic-list'][0].action).toBe('block');
+      expect(tg['topic-list'][0].topic).toHaveLength(1);
     });
 
     it('works with action=allow', async () => {
@@ -373,13 +367,12 @@ describe('SdkManagementService', () => {
       await service.assignTopicToProfile('test-profile', 'topic-1', 'Safe Topic', 'allow');
 
       const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
-      const allowEntry = tg['topic-list'].find((tl) => tl.action === 'allow');
-      expect(allowEntry?.topic).toEqual([
-        { topic_id: 'topic-1', topic_name: 'Safe Topic', revision: 1 },
+      // Only one entry for the allow action
+      expect(tg['topic-list']).toHaveLength(1);
+      expect(tg['topic-list'][0].action).toBe('allow');
+      expect(tg['topic-list'][0].topic).toEqual([
+        { topic_id: 'topic-1', topic_name: 'Safe Topic' },
       ]);
-      // Block list should be empty
-      const blockEntry = tg['topic-list'].find((tl) => tl.action === 'block');
-      expect(blockEntry?.topic).toEqual([]);
     });
 
     it('always sets guardrail-level action to block', async () => {


### PR DESCRIPTION
## Summary

- AIRS API returns 400 when `topic-list` contains empty entries (e.g. `{ action: 'allow', topic: [] }`)
- `assignTopicToProfile` was sending two `topic-list` entries (one for the action, one empty for the opposite action) — now sends a single entry with the active topic only
- Removed unnecessary `revision` field from topic entries
- Bump to v1.1.2

## Test plan

- [x] All 230 tests pass
- [x] Type check, lint, format clean
- [x] E2E validated: full generate loop with `--create-prompt-set` completed successfully against real AIRS

🤖 Generated with [Claude Code](https://claude.com/claude-code)