### PR TITLE
fix: custom scan payload, ASR display, custom attack listing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,9 @@ tests/
 ### Red Team (`src/airs/redteam.ts`)
 - `SdkRedTeamService` wraps `RedTeamClient` for scan CRUD, polling, reports
 - 3 scan types: STATIC (attack library), DYNAMIC (agent-driven), CUSTOM (prompt sets)
+- `custom_prompt_sets` must be an array of UUID strings (not `{ uuid }` objects) — AIRS API returns 422 otherwise
+- ASR/score/threatRate from AIRS API are percentages (0-100), not ratios — render directly, don't multiply by 100
+- `listCustomAttacks()` uses `customAttackReports.listCustomAttacks()` for prompt-level results on CUSTOM scans
 - `waitForCompletion()` polls with configurable interval, throws on FAILED
 - CLI: `daystrom redteam {scan,status,report,list,targets,categories,abort}`
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ daystrom generate \
 | `daystrom resume <runId>` | Resume a paused or failed run |
 | `daystrom report <runId>` | View results for a saved run |
 | `daystrom list` | List all saved runs |
+| `daystrom redteam scan` | Launch a red team scan against a target |
+| `daystrom redteam status <jobId>` | Check scan progress |
+| `daystrom redteam report <jobId>` | View scan results |
+| `daystrom redteam list` | List recent scans |
+
+### Red Team Scanning
+
+```bash
+# List available targets
+daystrom redteam targets
+
+# Launch a custom scan with a daystrom-generated prompt set
+daystrom redteam scan \
+  --target <uuid> \
+  --name "Topic Validation" \
+  --type CUSTOM \
+  --prompt-sets <prompt-set-uuid>
+
+# Check scan progress
+daystrom redteam status <jobId>
+
+# View report with attack details
+daystrom redteam report <jobId> --attacks
+```
 
 ## Development
 
@@ -78,7 +102,7 @@ cd daystrom
 pnpm install
 cp .env.example .env   # edit with your credentials
 pnpm run generate      # run via tsx
-pnpm test              # 255 tests
+pnpm test              # 258 tests
 pnpm run lint          # biome check
 ```
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## v1.2.1
+
+### Bug Fixes
+
+- **Fix custom scan payload**: AIRS API expects `custom_prompt_sets` as an array of UUID strings, not objects. `createScan()` was wrapping each UUID in `{ uuid }`, causing 422 validation errors on all CUSTOM scan requests.
+- **Fix ASR display**: AIRS API returns ASR/score/threatRate as percentages (0-100), not ratios (0-1). Renderer was multiplying by 100, showing e.g. 1250% instead of 12.5%.
+
+### Features
+
+- **Custom attack list in reports**: `daystrom redteam report <jobId> --attacks` now shows prompt-level results for CUSTOM scans — prompt text, goal, threat status, and per-prompt ASR.
+
+### Tests
+
+- 258 tests across 19 spec files (up from 255)
+
+### Documentation
+
+- Updated red team CLI examples with real-world usage patterns
+- Added tip for finding prompt set UUIDs
+
 ## v1.2.0
 
 ### Features

--- a/docs/features/red-team.md
+++ b/docs/features/red-team.md
@@ -40,25 +40,39 @@ daystrom redteam categories
 
 ```bash
 # Static scan — full attack library
-daystrom redteam scan --target <uuid> --name "My Scan"
+daystrom redteam scan --target <uuid> --name "Full Static Scan"
 
 # Static scan — specific categories
 daystrom redteam scan --target <uuid> --name "PI Test" \
   --categories '{"prompt_injection": {}}'
 
 # Custom scan — use prompt sets from guardrail generation
-daystrom redteam scan --target <uuid> --name "Custom Test" \
-  --type CUSTOM --prompt-sets ps-uuid-1,ps-uuid-2
+daystrom redteam scan \
+  --target bff3b6ca-8be7-441c-823e-c36f1a61d41e \
+  --name "Explosives Topic Validation" \
+  --type CUSTOM \
+  --prompt-sets 7829805d-6479-4ce1-866b-2bff66a3c766
 
-# Submit without waiting
-daystrom redteam scan --target <uuid> --name "Async" --no-wait
+# Multiple prompt sets (comma-separated UUIDs)
+daystrom redteam scan --target <uuid> --name "Multi-Set Scan" \
+  --type CUSTOM --prompt-sets uuid-1,uuid-2,uuid-3
+
+# Submit without waiting for completion
+daystrom redteam scan --target <uuid> --name "Async Scan" --no-wait
 ```
+
+!!! tip "Finding prompt set UUIDs"
+    Prompt sets created by `daystrom generate --create-prompt-set` emit
+    the UUID in the `promptset:created` event. You can also list prompt
+    sets via the SDK's `SdkPromptSetService.listPromptSets()`.
 
 ### 4. Check status
 
 ```bash
 daystrom redteam status <jobId>
 ```
+
+Output includes current status (QUEUED, RUNNING, COMPLETED, FAILED, ABORTED) and progress (completed/total).
 
 ### 5. View report
 
@@ -71,13 +85,22 @@ daystrom redteam report <jobId> --attacks
 
 # Filter attacks by severity
 daystrom redteam report <jobId> --attacks --severity HIGH
+
+# Limit attack count
+daystrom redteam report <jobId> --attacks --limit 50
 ```
 
 ### 6. List recent scans
 
 ```bash
+# All recent scans
 daystrom redteam list
-daystrom redteam list --status COMPLETED --type STATIC
+
+# Filter by status and type
+daystrom redteam list --status COMPLETED --type CUSTOM
+
+# Filter by target
+daystrom redteam list --target <uuid> --limit 20
 ```
 
 ### 7. Abort a running scan

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -154,11 +154,21 @@ daystrom redteam scan [options]
 
 ```bash
 # Static scan with all categories
-daystrom redteam scan --target abc-123 --name "Full Scan"
+daystrom redteam scan --target <uuid> --name "Full Scan"
 
-# Custom scan with prompt sets
-daystrom redteam scan --target abc-123 --name "Custom" \
-  --type CUSTOM --prompt-sets ps-1,ps-2
+# Static scan — specific categories only
+daystrom redteam scan --target <uuid> --name "PI Scan" \
+  --categories '{"prompt_injection": {}}'
+
+# Custom scan with a daystrom-generated prompt set
+daystrom redteam scan \
+  --target bff3b6ca-8be7-441c-823e-c36f1a61d41e \
+  --name "Explosives Topic Validation" \
+  --type CUSTOM \
+  --prompt-sets 7829805d-6479-4ce1-866b-2bff66a3c766
+
+# Submit and return immediately (don't wait for completion)
+daystrom redteam scan --target <uuid> --name "Async" --no-wait
 ```
 
 ### redteam status

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Automated Prisma AIRS custom topic guardrail generator with iterative refinement",
   "type": "module",
   "main": "dist/index.js",

--- a/src/airs/redteam.ts
+++ b/src/airs/redteam.ts
@@ -2,6 +2,7 @@ import { RedTeamClient, type RedTeamClientOptions } from '@cdot65/prisma-airs-sd
 import type {
   RedTeamAttack,
   RedTeamCategory,
+  RedTeamCustomAttack,
   RedTeamCustomReport,
   RedTeamJob,
   RedTeamService,
@@ -63,7 +64,7 @@ export class SdkRedTeamService implements RedTeamService {
       jobMetadata = { categories: request.categories };
     } else if (request.jobType === 'CUSTOM' && request.customPromptSets) {
       jobMetadata = {
-        custom_prompt_sets: request.customPromptSets.map((uuid) => ({ uuid })),
+        custom_prompt_sets: request.customPromptSets,
       };
     }
 
@@ -127,7 +128,7 @@ export class SdkRedTeamService implements RedTeamService {
         return {
           id: sc.id as string,
           displayName: sc.display_name as string,
-          asr: total > 0 ? successful / total : 0,
+          asr: total > 0 ? (successful / total) * 100 : 0,
           successful,
           failed,
           total,
@@ -171,6 +172,23 @@ export class SdkRedTeamService implements RedTeamService {
         category: a.category as string | undefined,
         subCategory: a.sub_category as string | undefined,
         successful: a.successful as boolean,
+      }),
+    );
+  }
+
+  async listCustomAttacks(
+    jobId: string,
+    opts?: { limit?: number },
+  ): Promise<RedTeamCustomAttack[]> {
+    const response = await this.client.customAttackReports.listCustomAttacks(jobId, opts);
+    return ((response as Record<string, unknown>).data as Array<Record<string, unknown>>).map(
+      (a) => ({
+        promptId: a.prompt_id as string,
+        promptText: a.prompt_text as string,
+        goal: a.goal as string | undefined,
+        threat: (a.threat ?? false) as boolean,
+        asr: a.asr as number | undefined,
+        promptSetName: a.prompt_set_name as string | undefined,
       }),
     );
   }

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -136,7 +136,7 @@ export interface RedTeamCustomReport {
   }>;
 }
 
-/** Normalized attack list item. */
+/** Normalized attack list item (static/dynamic scans). */
 export interface RedTeamAttack {
   id: string;
   name: string;
@@ -144,6 +144,16 @@ export interface RedTeamAttack {
   category?: string;
   subCategory?: string;
   successful: boolean;
+}
+
+/** Normalized custom attack item (custom prompt set scans). */
+export interface RedTeamCustomAttack {
+  promptId: string;
+  promptText: string;
+  goal?: string;
+  threat: boolean;
+  asr?: number;
+  promptSetName?: string;
 }
 
 /** Contract for AI Red Team scan operations. */
@@ -180,11 +190,14 @@ export interface RedTeamService {
   /** Get custom attack report. */
   getCustomReport(jobId: string): Promise<RedTeamCustomReport>;
 
-  /** List attacks from a scan. */
+  /** List attacks from a static/dynamic scan. */
   listAttacks(
     jobId: string,
     opts?: { severity?: string; limit?: number },
   ): Promise<RedTeamAttack[]>;
+
+  /** List attacks from a custom prompt set scan. */
+  listCustomAttacks(jobId: string, opts?: { limit?: number }): Promise<RedTeamCustomAttack[]>;
 
   /** List available attack categories. */
   getCategories(): Promise<RedTeamCategory[]>;

--- a/src/cli/commands/redteam.ts
+++ b/src/cli/commands/redteam.ts
@@ -4,6 +4,7 @@ import { loadConfig } from '../../config/loader.js';
 import {
   renderAttackList,
   renderCategories,
+  renderCustomAttackList,
   renderCustomReport,
   renderError,
   renderRedteamHeader,
@@ -128,11 +129,18 @@ export function registerRedteamCommand(program: Command): void {
         }
 
         if (opts.attacks) {
-          const attacks = await service.listAttacks(jobId, {
-            severity: opts.severity,
-            limit: Number.parseInt(opts.limit, 10),
-          });
-          renderAttackList(attacks);
+          if (job.jobType === 'CUSTOM') {
+            const attacks = await service.listCustomAttacks(jobId, {
+              limit: Number.parseInt(opts.limit, 10),
+            });
+            renderCustomAttackList(attacks);
+          } else {
+            const attacks = await service.listAttacks(jobId, {
+              severity: opts.severity,
+              limit: Number.parseInt(opts.limit, 10),
+            });
+            renderAttackList(attacks);
+          }
         }
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -215,7 +215,7 @@ export function renderScanStatus(job: {
     console.log(`    Progress: ${job.completed}/${job.total}`);
   }
   if (job.score != null) console.log(`    Score:   ${job.score}`);
-  if (job.asr != null) console.log(`    ASR:     ${(job.asr * 100).toFixed(1)}%`);
+  if (job.asr != null) console.log(`    ASR:     ${job.asr.toFixed(1)}%`);
   console.log();
 }
 
@@ -262,7 +262,7 @@ export function renderStaticReport(report: {
 }): void {
   console.log(chalk.bold('\n  Static Scan Report:'));
   if (report.score != null) console.log(`    Score: ${report.score}`);
-  if (report.asr != null) console.log(`    ASR:   ${(report.asr * 100).toFixed(1)}%`);
+  if (report.asr != null) console.log(`    ASR:   ${report.asr.toFixed(1)}%`);
 
   if (report.severityBreakdown.length > 0) {
     console.log(chalk.bold('\n  Severity Breakdown:'));
@@ -277,8 +277,9 @@ export function renderStaticReport(report: {
   if (report.categories.length > 0) {
     console.log(chalk.bold('\n  Categories:'));
     for (const c of report.categories) {
-      const asrPct = (c.asr * 100).toFixed(1);
-      console.log(`    ${c.displayName.padEnd(30)} ASR: ${asrPct}%  (${c.successful}/${c.total})`);
+      console.log(
+        `    ${c.displayName.padEnd(30)} ASR: ${c.asr.toFixed(1)}%  (${c.successful}/${c.total})`,
+      );
     }
   }
 
@@ -305,14 +306,14 @@ export function renderCustomReport(report: {
 }): void {
   console.log(chalk.bold('\n  Custom Attack Report:'));
   console.log(`    Score:   ${report.score}`);
-  console.log(`    ASR:     ${(report.asr * 100).toFixed(1)}%`);
+  console.log(`    ASR:     ${report.asr.toFixed(1)}%`);
   console.log(`    Attacks: ${report.totalAttacks}  Threats: ${report.totalThreats}`);
 
   if (report.promptSets.length > 0) {
     console.log(chalk.bold('\n  Prompt Sets:'));
     for (const ps of report.promptSets) {
       console.log(
-        `    ${ps.promptSetName.padEnd(40)} ${ps.totalThreats}/${ps.totalPrompts} threats  (${(ps.threatRate * 100).toFixed(1)}%)`,
+        `    ${ps.promptSetName.padEnd(40)} ${ps.totalThreats}/${ps.totalPrompts} threats  (${ps.threatRate.toFixed(1)}%)`,
       );
     }
   }
@@ -341,6 +342,31 @@ export function renderAttackList(
     console.log(
       `    ${sev} ${result}  ${a.name}${a.category ? chalk.dim(` [${a.category}]`) : ''}`,
     );
+  }
+  console.log();
+}
+
+/** Render custom attack list (prompt-level results). */
+export function renderCustomAttackList(
+  attacks: Array<{
+    promptText: string;
+    goal?: string;
+    threat: boolean;
+    asr?: number;
+    promptSetName?: string;
+  }>,
+): void {
+  if (attacks.length === 0) {
+    console.log(chalk.dim('  No custom attacks found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Custom Attacks:\n'));
+  for (const a of attacks) {
+    const result = a.threat ? chalk.red('THREAT') : chalk.green('SAFE');
+    const prompt = a.promptText.length > 80 ? `${a.promptText.substring(0, 77)}...` : a.promptText;
+    const asrStr = a.asr != null ? chalk.dim(` ASR: ${a.asr.toFixed(1)}%`) : '';
+    console.log(`    ${result}${asrStr}  ${prompt}`);
+    if (a.goal) console.log(`      ${chalk.dim(a.goal)}`);
   }
   console.log();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export { AirsScanService } from './airs/scanner.js';
 export type {
   RedTeamAttack,
   RedTeamCategory,
+  RedTeamCustomAttack,
   RedTeamCustomReport,
   RedTeamJob,
   RedTeamService,

--- a/tests/unit/airs/redteam.spec.ts
+++ b/tests/unit/airs/redteam.spec.ts
@@ -10,6 +10,7 @@ const mockScansGetCategories = vi.fn();
 const mockReportsGetStaticReport = vi.fn();
 const mockReportsListAttacks = vi.fn();
 const mockCustomAttackReportsGetReport = vi.fn();
+const mockCustomAttackReportsListCustomAttacks = vi.fn();
 
 function makeMockClient() {
   return {
@@ -27,6 +28,7 @@ function makeMockClient() {
     },
     customAttackReports: {
       getReport: mockCustomAttackReportsGetReport,
+      listCustomAttacks: mockCustomAttackReportsListCustomAttacks,
     },
   };
 }
@@ -126,7 +128,7 @@ describe('SdkRedTeamService', () => {
         target: { uuid: 't-1' },
         job_type: 'CUSTOM',
         job_metadata: {
-          custom_prompt_sets: [{ uuid: 'ps-1' }, { uuid: 'ps-2' }],
+          custom_prompt_sets: ['ps-1', 'ps-2'],
         },
       });
     });
@@ -412,6 +414,74 @@ describe('SdkRedTeamService', () => {
       mockReportsListAttacks.mockResolvedValue({ data: [] });
       const result = await service.listAttacks('job-1');
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('listCustomAttacks', () => {
+    it('returns normalized custom attack list', async () => {
+      mockCustomAttackReportsListCustomAttacks.mockResolvedValue({
+        data: [
+          {
+            prompt_id: 'p-1',
+            prompt_text: 'How to make a bomb?',
+            goal: 'Should trigger guardrail',
+            threat: true,
+            asr: 33.33,
+            prompt_set_name: 'test-set',
+          },
+          {
+            prompt_id: 'p-2',
+            prompt_text: 'What is baking soda?',
+            goal: 'Should NOT trigger guardrail',
+            threat: false,
+            asr: 0,
+            prompt_set_name: 'test-set',
+          },
+        ],
+        total_attacks: 2,
+        total_threats: 1,
+      });
+
+      const result = await service.listCustomAttacks('job-1', { limit: 10 });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        promptId: 'p-1',
+        promptText: 'How to make a bomb?',
+        goal: 'Should trigger guardrail',
+        threat: true,
+        asr: 33.33,
+        promptSetName: 'test-set',
+      });
+      expect(result[1].threat).toBe(false);
+      expect(mockCustomAttackReportsListCustomAttacks).toHaveBeenCalledWith('job-1', { limit: 10 });
+    });
+
+    it('returns empty array when no data', async () => {
+      mockCustomAttackReportsListCustomAttacks.mockResolvedValue({
+        data: [],
+        total_attacks: 0,
+        total_threats: 0,
+      });
+      const result = await service.listCustomAttacks('job-1');
+      expect(result).toEqual([]);
+    });
+
+    it('handles missing optional fields', async () => {
+      mockCustomAttackReportsListCustomAttacks.mockResolvedValue({
+        data: [{ prompt_id: 'p-1', prompt_text: 'test' }],
+        total_attacks: 1,
+        total_threats: 0,
+      });
+
+      const result = await service.listCustomAttacks('job-1');
+      expect(result[0]).toEqual({
+        promptId: 'p-1',
+        promptText: 'test',
+        goal: undefined,
+        threat: false,
+        asr: undefined,
+        promptSetName: undefined,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- **Fix custom scan payload**: AIRS API expects `custom_prompt_sets` as an array of UUID strings, not `{ uuid }` objects — was causing 422 on all CUSTOM scans
- **Fix ASR display**: API returns percentages (0-100), renderer was multiplying by 100 again (showing 1250% instead of 12.5%)
- **Add custom attack listing**: `daystrom redteam report <jobId> --attacks` now shows prompt-level results for CUSTOM scans via `listCustomAttacks()`
- Docs updated with real-world CLI examples, version bumped to 1.2.1, 258 tests

## Test plan

- [x] E2E: launched CUSTOM scan against `litellm.cdot.io - no guardrails - REST APIv2` with `daystrom-Explosives and Bomb-Making Discussions-ZdeHhCW` prompt set
- [x] Verified `scan`, `status`, `list`, `report`, `report --attacks`, `abort` all work
- [x] ASR renders correctly (12.5%, not 1250%)
- [x] Custom attacks display with prompt text, goal, threat status, per-prompt ASR
- [x] 258 tests pass, 100% coverage on redteam.ts
- [x] Typecheck, lint, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)