### PR TITLE
feat: structured evaluation reports (JSON/HTML export)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,16 +82,21 @@ src/
 ├── persistence/
 │   ├── store.ts           # JsonFileStore — save/load/list RunState as JSON
 │   └── types.ts           # RunStore, RunStateSummary
+├── report/
+│   ├── types.ts           # ReportOutput, TestDetail, RunDiff, MetricsDelta
+│   ├── json.ts            # buildReportJson() — RunState → structured ReportOutput
+│   └── html.ts            # buildReportHtml() — ReportOutput → self-contained HTML
 └── index.ts               # Library exports
 
 tests/
-├── unit/                  # 16 spec files
+├── unit/                  # 19 spec files
 │   ├── airs/              # scanner.spec.ts, management.spec.ts
 │   ├── config/            # schema.spec.ts, loader.spec.ts
 │   ├── core/              # loop.spec.ts, metrics.spec.ts, constraints.spec.ts
 │   ├── llm/               # provider.spec.ts, schemas.spec.ts, service.spec.ts, prompts.spec.ts
 │   ├── memory/            # store.spec.ts, extractor.spec.ts, injector.spec.ts, diff.spec.ts
-│   └── persistence/       # store.spec.ts
+│   ├── persistence/       # store.spec.ts
+│   └── report/            # json.spec.ts, html.spec.ts
 ├── integration/           # loop.integration.spec.ts (full loop w/ mocks)
 ├── e2e/                   # vertex-provider.e2e.spec.ts (opt-in, requires real creds)
 └── helpers/               # mocks.ts
@@ -152,6 +157,12 @@ tests/
 
 ### Persistence (`src/persistence/`)
 - `JsonFileStore` saves/loads `RunState` as JSON at `~/.daystrom/runs/{runId}.json`
+
+### Reports (`src/report/`)
+- `buildReportJson(run, opts)` maps `RunState` → `ReportOutput` (pure function, no I/O)
+- `buildReportHtml(report)` renders `ReportOutput` → self-contained HTML string
+- `--format json|html|terminal`, `--tests` for per-test details, `--diff <runId>` for run comparison
+- HTML includes embedded CSS, iteration trends table, metrics, test result tables, diff sections
 
 ## AIRS Constraints (`src/core/constraints.ts`)
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,20 @@
 # Release Notes
 
+## v1.5.0
+
+### Features
+
+- **Structured evaluation reports**: `daystrom report` now supports `--format json` and `--format html` for machine-readable and shareable report export.
+- **Per-test-case details**: `--tests` flag includes individual test results (prompt, expected/actual outcome, pass/fail, category, source) in all output formats.
+- **Run comparison**: `--diff <runId>` compares two runs side-by-side with metric deltas (coverage, TPR, TNR, accuracy, F1).
+- **Self-contained HTML reports**: HTML output includes embedded CSS with run summary, iteration trends, metrics tables, test result tables, and diff sections. No external dependencies.
+- **JSON export**: Clean structured JSON to stdout for CI/CD pipelines and programmatic consumption.
+- **New report module**: `buildReportJson()` and `buildReportHtml()` exported as library functions for custom integrations.
+
+### Tests
+
+- 298 tests across 21 spec files (up from 272)
+
 ## v1.4.0
 
 ### Features

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -108,13 +108,26 @@ daystrom report <runId> [options]
 | Flag | Default | What it does |
 |------|---------|-------------|
 | `--iteration <n>` | _(best)_ | Show a specific iteration instead of the best |
+| `--format <fmt>` | `terminal` | Output format: `terminal`, `json`, `html` |
+| `--tests` | _(off)_ | Include per-test-case details |
+| `--diff <runId>` | _(none)_ | Compare with another run side-by-side |
+| `--output <path>` | `<runId>-report.html` | Output file path (html format only) |
 
 ```bash
-# Best iteration
+# Best iteration (terminal)
 daystrom report abc123xyz
 
 # Specific iteration
 daystrom report abc123xyz --iteration 3
+
+# JSON export (to stdout)
+daystrom report abc123xyz --format json --tests
+
+# HTML report with test details
+daystrom report abc123xyz --format html --tests --output my-report.html
+
+# Compare two runs
+daystrom report abc123xyz --diff def456uvw
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Automated Prisma AIRS custom topic guardrail generator with iterative refinement",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -1,12 +1,16 @@
+import { writeFile } from 'node:fs/promises';
 import chalk from 'chalk';
 import type { Command } from 'commander';
 import { loadConfig } from '../../config/loader.js';
 import { JsonFileStore } from '../../persistence/store.js';
+import { buildReportHtml } from '../../report/html.js';
+import { buildReportJson } from '../../report/json.js';
 import {
   renderAnalysis,
   renderError,
   renderHeader,
   renderMetrics,
+  renderTestResults,
   renderTopic,
 } from '../renderer.js';
 
@@ -16,9 +20,12 @@ export function registerReportCommand(program: Command): void {
     .command('report <runId>')
     .description('View detailed report for a run')
     .option('--iteration <n>', 'Show specific iteration')
+    .option('--format <format>', 'Output format: terminal, json, html', 'terminal')
+    .option('--tests', 'Include per-test-case details')
+    .option('--diff <runId>', 'Compare with another run')
+    .option('--output <path>', 'Output file path (html format)')
     .action(async (runId: string, opts) => {
       try {
-        renderHeader();
         const config = await loadConfig();
         const store = new JsonFileStore(config.dataDir);
         const run = await store.load(runId);
@@ -28,6 +35,40 @@ export function registerReportCommand(program: Command): void {
           process.exit(1);
         }
 
+        let diffRun: Awaited<ReturnType<typeof store.load>> = null;
+        if (opts.diff) {
+          diffRun = await store.load(opts.diff);
+          if (!diffRun) {
+            renderError(`Diff run ${opts.diff} not found`);
+            process.exit(1);
+          }
+        }
+
+        const format: string = opts.format;
+
+        if (format === 'json') {
+          const report = buildReportJson(run, {
+            includeTests: opts.tests ?? false,
+            diffRun,
+          });
+          console.log(JSON.stringify(report, null, 2));
+          return;
+        }
+
+        if (format === 'html') {
+          const report = buildReportJson(run, {
+            includeTests: opts.tests ?? false,
+            diffRun,
+          });
+          const html = buildReportHtml(report);
+          const outputPath = opts.output ?? `${runId}-report.html`;
+          await writeFile(outputPath, html, 'utf-8');
+          console.log(chalk.green(`  Report written to ${outputPath}`));
+          return;
+        }
+
+        // Terminal format (default — unchanged behavior)
+        renderHeader();
         console.log(chalk.bold(`\n  Run: ${run.id}`));
         console.log(`  Status: ${run.status}`);
         console.log(`  Created: ${run.createdAt}`);
@@ -49,6 +90,7 @@ export function registerReportCommand(program: Command): void {
           renderTopic(iter.topic);
           renderMetrics(iter.metrics);
           renderAnalysis(iter.analysis);
+          if (opts.tests) renderTestResults(iter.testResults);
         } else {
           // Show best iteration
           const best = run.iterations[run.bestIteration - 1];
@@ -57,8 +99,29 @@ export function registerReportCommand(program: Command): void {
             renderTopic(best.topic);
             renderMetrics(best.metrics);
             renderAnalysis(best.analysis);
+            if (opts.tests) renderTestResults(best.testResults);
           }
         }
+
+        if (opts.diff && diffRun) {
+          const report = buildReportJson(run, { diffRun });
+          if (report.diff) {
+            const d = report.diff;
+            console.log(chalk.bold('\n  Run Comparison:'));
+            console.log(`  Base: ${d.baseRunId} | Compare: ${d.compareRunId}`);
+            const fmtDelta = (label: string, val: number) => {
+              const sign = val >= 0 ? '+' : '';
+              const color = val > 0 ? chalk.green : val < 0 ? chalk.red : chalk.gray;
+              console.log(`  ${label}: ${color(`${sign}${(val * 100).toFixed(1)}%`)}`);
+            };
+            fmtDelta('Coverage', d.metricsDelta.coverage);
+            fmtDelta('TPR', d.metricsDelta.tpr);
+            fmtDelta('TNR', d.metricsDelta.tnr);
+            fmtDelta('Accuracy', d.metricsDelta.accuracy);
+            fmtDelta('F1', d.metricsDelta.f1);
+          }
+        }
+
         console.log();
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -5,6 +5,7 @@ import type {
   EfficacyMetrics,
   IterationResult,
   RunState,
+  TestResult,
 } from '../core/types.js';
 import type { RunStateSummary } from '../persistence/types.js';
 
@@ -71,6 +72,18 @@ export function renderAnalysis(analysis: AnalysisReport): void {
     for (const p of analysis.falseNegativePatterns) {
       console.log(`      ${chalk.dim('•')} ${p}`);
     }
+  }
+}
+
+/** Render per-test-case results table. */
+export function renderTestResults(results: TestResult[]): void {
+  console.log(chalk.bold('\n  Test Results:'));
+  for (const r of results) {
+    const icon = r.correct ? chalk.green('✓') : chalk.red('✗');
+    const expected = r.testCase.expectedTriggered ? 'triggered' : 'safe';
+    const actual = r.actualTriggered ? 'triggered' : 'safe';
+    const status = r.correct ? '' : chalk.red(` (expected ${expected}, got ${actual})`);
+    console.log(`    ${icon} ${r.testCase.prompt}${status}`);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,3 +77,17 @@ export type {
 // Persistence — save/load/list run state as JSON for resume & reporting
 // ---------------------------------------------------------------------------
 export { JsonFileStore } from './persistence/store.js';
+
+// ---------------------------------------------------------------------------
+// Reports — structured evaluation report generation (JSON/HTML)
+// ---------------------------------------------------------------------------
+export { buildReportHtml } from './report/html.js';
+export { buildReportJson } from './report/json.js';
+export type {
+  IterationSummary,
+  MetricsDelta,
+  ReportOutput,
+  RunDiff,
+  RunSummary,
+  TestDetail,
+} from './report/types.js';

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -1,0 +1,223 @@
+/**
+ * HTML report builder — self-contained HTML from ReportOutput.
+ */
+
+import type { EfficacyMetrics } from '../core/types.js';
+import type { IterationSummary, ReportOutput, RunDiff, TestDetail } from './types.js';
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+function delta(n: number): string {
+  const sign = n >= 0 ? '+' : '';
+  return `${sign}${(n * 100).toFixed(1)}%`;
+}
+
+function deltaClass(n: number): string {
+  if (n > 0) return 'positive';
+  if (n < 0) return 'negative';
+  return 'neutral';
+}
+
+function renderMetricsTable(m: EfficacyMetrics): string {
+  return `<table class="metrics">
+    <tr><th>Coverage</th><td>${pct(m.coverage)}</td></tr>
+    <tr><th>Accuracy</th><td>${pct(m.accuracy)}</td></tr>
+    <tr><th>TPR</th><td>${pct(m.truePositiveRate)}</td></tr>
+    <tr><th>TNR</th><td>${pct(m.trueNegativeRate)}</td></tr>
+    <tr><th>F1</th><td>${pct(m.f1Score)}</td></tr>
+    <tr><th>TP</th><td>${m.truePositives}</td></tr>
+    <tr><th>TN</th><td>${m.trueNegatives}</td></tr>
+    <tr><th>FP</th><td>${m.falsePositives}</td></tr>
+    <tr><th>FN</th><td>${m.falseNegatives}</td></tr>
+    <tr><th>Regressions</th><td>${m.regressionCount}</td></tr>
+  </table>`;
+}
+
+function renderTestTable(tests: TestDetail[]): string {
+  const rows = tests
+    .map(
+      (t) =>
+        `<tr class="${t.correct ? 'pass' : 'fail'}">
+      <td>${esc(t.prompt)}</td>
+      <td>${t.expectedTriggered ? 'Yes' : 'No'}</td>
+      <td>${t.actualTriggered ? 'Yes' : 'No'}</td>
+      <td>${t.correct ? 'Pass' : 'Fail'}</td>
+      <td>${esc(t.category)}</td>
+      <td>${t.source ? esc(t.source) : '-'}</td>
+      <td>${t.scanAction}</td>
+    </tr>`,
+    )
+    .join('\n');
+
+  return `<table class="tests">
+    <thead><tr>
+      <th>Prompt</th><th>Expected</th><th>Actual</th><th>Result</th>
+      <th>Category</th><th>Source</th><th>Action</th>
+    </tr></thead>
+    <tbody>${rows}</tbody>
+  </table>`;
+}
+
+function renderIteration(iter: IterationSummary): string {
+  const examplesHtml =
+    iter.topic.examples.length > 0
+      ? `<ul>${iter.topic.examples.map((e) => `<li>${esc(e)}</li>`).join('')}</ul>`
+      : '<p>None</p>';
+
+  const analysisHtml = `
+    <p>${esc(iter.analysis.summary)}</p>
+    ${iter.analysis.falsePositivePatterns.length > 0 ? `<p><strong>FP Patterns:</strong> ${iter.analysis.falsePositivePatterns.map(esc).join('; ')}</p>` : ''}
+    ${iter.analysis.falseNegativePatterns.length > 0 ? `<p><strong>FN Patterns:</strong> ${iter.analysis.falseNegativePatterns.map(esc).join('; ')}</p>` : ''}
+    ${iter.analysis.suggestions.length > 0 ? `<p><strong>Suggestions:</strong> ${iter.analysis.suggestions.map(esc).join('; ')}</p>` : ''}
+  `;
+
+  const testsHtml = iter.tests ? `<h4>Test Results</h4>${renderTestTable(iter.tests)}` : '';
+
+  return `<section class="iteration">
+    <h3>Iteration ${iter.iteration}</h3>
+    <p class="meta">Duration: ${(iter.durationMs / 1000).toFixed(1)}s | ${iter.timestamp}</p>
+    <h4>Topic</h4>
+    <p><strong>${esc(iter.topic.name)}</strong></p>
+    <p>${esc(iter.topic.description)}</p>
+    <h4>Examples</h4>
+    ${examplesHtml}
+    <h4>Metrics</h4>
+    ${renderMetricsTable(iter.metrics)}
+    <h4>Analysis</h4>
+    ${analysisHtml}
+    ${testsHtml}
+  </section>`;
+}
+
+function renderTrends(iterations: IterationSummary[]): string {
+  if (iterations.length < 2) return '';
+
+  const rows = iterations
+    .map(
+      (iter) =>
+        `<tr>
+      <td>${iter.iteration}</td>
+      <td>${pct(iter.metrics.coverage)}</td>
+      <td>${pct(iter.metrics.truePositiveRate)}</td>
+      <td>${pct(iter.metrics.trueNegativeRate)}</td>
+      <td>${pct(iter.metrics.accuracy)}</td>
+      <td>${pct(iter.metrics.f1Score)}</td>
+      <td>${iter.metrics.falsePositives}</td>
+      <td>${iter.metrics.falseNegatives}</td>
+    </tr>`,
+    )
+    .join('\n');
+
+  return `<section class="trends">
+    <h2>Iteration Trends</h2>
+    <table class="metrics">
+      <thead><tr>
+        <th>Iter</th><th>Coverage</th><th>TPR</th><th>TNR</th>
+        <th>Accuracy</th><th>F1</th><th>FP</th><th>FN</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+  </section>`;
+}
+
+function renderDiff(diff: RunDiff): string {
+  const d = diff.metricsDelta;
+  return `<section class="diff">
+    <h2>Run Comparison</h2>
+    <table class="metrics">
+      <thead><tr><th>Metric</th><th>${esc(diff.baseRunId)}</th><th>${esc(diff.compareRunId)}</th><th>Delta</th></tr></thead>
+      <tbody>
+        <tr><td>Coverage</td><td>${pct(diff.baseMetrics.coverage)}</td><td>${pct(diff.compareMetrics.coverage)}</td><td class="${deltaClass(d.coverage)}">${delta(d.coverage)}</td></tr>
+        <tr><td>TPR</td><td>${pct(diff.baseMetrics.truePositiveRate)}</td><td>${pct(diff.compareMetrics.truePositiveRate)}</td><td class="${deltaClass(d.tpr)}">${delta(d.tpr)}</td></tr>
+        <tr><td>TNR</td><td>${pct(diff.baseMetrics.trueNegativeRate)}</td><td>${pct(diff.compareMetrics.trueNegativeRate)}</td><td class="${deltaClass(d.tnr)}">${delta(d.tnr)}</td></tr>
+        <tr><td>Accuracy</td><td>${pct(diff.baseMetrics.accuracy)}</td><td>${pct(diff.compareMetrics.accuracy)}</td><td class="${deltaClass(d.accuracy)}">${delta(d.accuracy)}</td></tr>
+        <tr><td>F1</td><td>${pct(diff.baseMetrics.f1Score)}</td><td>${pct(diff.compareMetrics.f1Score)}</td><td class="${deltaClass(d.f1)}">${delta(d.f1)}</td></tr>
+      </tbody>
+    </table>
+    <h3>Topic Comparison</h3>
+    <div class="topic-diff">
+      <div><h4>Base</h4><p><strong>${esc(diff.baseTopic.name)}</strong></p><p>${esc(diff.baseTopic.description)}</p></div>
+      <div><h4>Compare</h4><p><strong>${esc(diff.compareTopic.name)}</strong></p><p>${esc(diff.compareTopic.description)}</p></div>
+    </div>
+  </section>`;
+}
+
+export function buildReportHtml(report: ReportOutput): string {
+  const iterationsHtml = report.iterations.map(renderIteration).join('\n');
+  const trendsHtml = renderTrends(report.iterations);
+  const diffHtml = report.diff ? renderDiff(report.diff) : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Daystrom Report — ${esc(report.run.id)}</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 1200px; margin: 0 auto; padding: 2rem; background: #f8f9fa; color: #212529; }
+    h1 { font-size: 1.8rem; margin-bottom: 0.5rem; }
+    h2 { font-size: 1.4rem; margin: 1.5rem 0 0.75rem; border-bottom: 2px solid #dee2e6; padding-bottom: 0.25rem; }
+    h3 { font-size: 1.1rem; margin: 1rem 0 0.5rem; }
+    h4 { font-size: 0.95rem; margin: 0.75rem 0 0.25rem; color: #495057; }
+    .header { background: #212529; color: #fff; padding: 1.5rem; border-radius: 8px; margin-bottom: 1.5rem; }
+    .header h1 { color: #fff; }
+    .header .meta { color: #adb5bd; font-size: 0.9rem; }
+    .summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+    .summary-card { background: #fff; padding: 1rem; border-radius: 6px; border: 1px solid #dee2e6; }
+    .summary-card .label { font-size: 0.8rem; color: #6c757d; text-transform: uppercase; }
+    .summary-card .value { font-size: 1.3rem; font-weight: 600; }
+    table { width: 100%; border-collapse: collapse; margin: 0.5rem 0 1rem; }
+    th, td { padding: 0.5rem 0.75rem; text-align: left; border-bottom: 1px solid #dee2e6; }
+    th { background: #f1f3f5; font-size: 0.85rem; text-transform: uppercase; color: #495057; }
+    .pass td:nth-child(4) { color: #2b8a3e; font-weight: 600; }
+    .fail td:nth-child(4) { color: #c92a2a; font-weight: 600; }
+    .iteration { background: #fff; padding: 1.25rem; border-radius: 6px; border: 1px solid #dee2e6; margin-bottom: 1rem; }
+    .meta { font-size: 0.85rem; color: #868e96; }
+    .positive { color: #2b8a3e; }
+    .negative { color: #c92a2a; }
+    .neutral { color: #868e96; }
+    .trends { background: #fff; padding: 1.25rem; border-radius: 6px; border: 1px solid #dee2e6; margin-bottom: 1rem; }
+    .diff { background: #fff; padding: 1.25rem; border-radius: 6px; border: 1px solid #dee2e6; margin-bottom: 1rem; }
+    .topic-diff { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+    .tests { font-size: 0.85rem; }
+    .tests td:first-child { max-width: 400px; word-break: break-word; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>Daystrom Evaluation Report</h1>
+    <p class="meta">Generated ${esc(report.generatedAt)} | Run ${esc(report.run.id)}</p>
+  </div>
+
+  <div class="summary">
+    <div class="summary-card"><div class="label">Status</div><div class="value">${esc(report.run.status)}</div></div>
+    <div class="summary-card"><div class="label">Intent</div><div class="value">${esc(report.run.intent)}</div></div>
+    <div class="summary-card"><div class="label">Best Coverage</div><div class="value">${pct(report.run.bestCoverage)}</div></div>
+    <div class="summary-card"><div class="label">Iterations</div><div class="value">${report.run.totalIterations}</div></div>
+    <div class="summary-card"><div class="label">Best Iteration</div><div class="value">#${report.run.bestIteration}</div></div>
+    <div class="summary-card"><div class="label">Profile</div><div class="value">${esc(report.run.profileName)}</div></div>
+  </div>
+
+  <h2>Topic</h2>
+  <p>${esc(report.run.topicDescription)}</p>
+
+  ${trendsHtml}
+
+  <h2>Iterations</h2>
+  ${iterationsHtml}
+
+  ${diffHtml}
+</body>
+</html>`;
+}

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -1,0 +1,90 @@
+/**
+ * JSON report builder — pure function mapping RunState to structured ReportOutput.
+ */
+
+import type { RunState } from '../core/types.js';
+import type { IterationSummary, ReportOutput, RunDiff, TestDetail } from './types.js';
+
+export interface BuildReportOptions {
+  includeTests?: boolean;
+  diffRun?: RunState | null;
+}
+
+export function buildReportJson(run: RunState, options: BuildReportOptions = {}): ReportOutput {
+  const iterations: IterationSummary[] = run.iterations.map((iter) => {
+    const summary: IterationSummary = {
+      iteration: iter.iteration,
+      timestamp: iter.timestamp,
+      durationMs: iter.durationMs,
+      topic: iter.topic,
+      metrics: iter.metrics,
+      analysis: iter.analysis,
+    };
+
+    if (options.includeTests) {
+      summary.tests = iter.testResults.map((r): TestDetail => {
+        const detail: TestDetail = {
+          prompt: r.testCase.prompt,
+          expectedTriggered: r.testCase.expectedTriggered,
+          actualTriggered: r.actualTriggered,
+          correct: r.correct,
+          category: r.testCase.category,
+          scanAction: r.scanAction,
+        };
+        if (r.testCase.source) {
+          detail.source = r.testCase.source;
+        }
+        return detail;
+      });
+    }
+
+    return summary;
+  });
+
+  const report: ReportOutput = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    run: {
+      id: run.id,
+      createdAt: run.createdAt,
+      status: run.status,
+      intent: run.userInput.intent,
+      topicDescription: run.userInput.topicDescription,
+      profileName: run.userInput.profileName,
+      bestIteration: run.bestIteration,
+      bestCoverage: run.bestCoverage,
+      totalIterations: run.iterations.length,
+    },
+    iterations,
+  };
+
+  if (options.diffRun) {
+    report.diff = buildDiff(run, options.diffRun);
+  }
+
+  return report;
+}
+
+function buildDiff(baseRun: RunState, compareRun: RunState): RunDiff {
+  const baseIter = baseRun.iterations[baseRun.bestIteration - 1];
+  const compareIter = compareRun.iterations[compareRun.bestIteration - 1];
+
+  const baseMetrics = baseIter.metrics;
+  const compareMetrics = compareIter.metrics;
+
+  return {
+    baseRunId: baseRun.id,
+    compareRunId: compareRun.id,
+    metricsDelta: {
+      coverage: compareMetrics.coverage - baseMetrics.coverage,
+      tpr: compareMetrics.truePositiveRate - baseMetrics.truePositiveRate,
+      tnr: compareMetrics.trueNegativeRate - baseMetrics.trueNegativeRate,
+      accuracy: compareMetrics.accuracy - baseMetrics.accuracy,
+      f1: compareMetrics.f1Score - baseMetrics.f1Score,
+    },
+    baseMetrics,
+    compareMetrics,
+    baseTopic: baseIter.topic,
+    compareTopic: compareIter.topic,
+  };
+}

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Structured evaluation report types — JSON/HTML export for run results.
+ */
+
+import type { AnalysisReport, CustomTopic, EfficacyMetrics } from '../core/types.js';
+
+/** Top-level report output structure. */
+export interface ReportOutput {
+  version: 1;
+  generatedAt: string;
+  run: RunSummary;
+  iterations: IterationSummary[];
+  diff?: RunDiff;
+}
+
+export interface RunSummary {
+  id: string;
+  createdAt: string;
+  status: string;
+  intent: 'allow' | 'block';
+  topicDescription: string;
+  profileName: string;
+  bestIteration: number;
+  bestCoverage: number;
+  totalIterations: number;
+}
+
+export interface IterationSummary {
+  iteration: number;
+  timestamp: string;
+  durationMs: number;
+  topic: CustomTopic;
+  metrics: EfficacyMetrics;
+  analysis: AnalysisReport;
+  tests?: TestDetail[];
+}
+
+export interface TestDetail {
+  prompt: string;
+  expectedTriggered: boolean;
+  actualTriggered: boolean;
+  correct: boolean;
+  category: string;
+  source?: string;
+  scanAction: 'allow' | 'block';
+}
+
+export interface RunDiff {
+  baseRunId: string;
+  compareRunId: string;
+  metricsDelta: MetricsDelta;
+  baseMetrics: EfficacyMetrics;
+  compareMetrics: EfficacyMetrics;
+  baseTopic: CustomTopic;
+  compareTopic: CustomTopic;
+}
+
+export interface MetricsDelta {
+  coverage: number;
+  tpr: number;
+  tnr: number;
+  accuracy: number;
+  f1: number;
+}

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -6,7 +6,15 @@ import type {
   ScanService,
   SdkCustomTopic,
 } from '../../src/airs/types.js';
-import type { AnalysisReport, CustomTopic, TestCase } from '../../src/core/types.js';
+import type {
+  AnalysisReport,
+  CustomTopic,
+  EfficacyMetrics,
+  IterationResult,
+  RunState,
+  TestCase,
+  TestResult,
+} from '../../src/core/types.js';
 
 export function mockTopic(overrides: Partial<CustomTopic> = {}): CustomTopic {
   return {
@@ -134,6 +142,100 @@ export function createMockAllowScanService(allowPatterns: RegExp[] = []): ScanSe
       }
       return results;
     },
+  };
+}
+
+export function mockMetrics(overrides: Partial<EfficacyMetrics> = {}): EfficacyMetrics {
+  return {
+    truePositives: 2,
+    trueNegatives: 2,
+    falsePositives: 0,
+    falseNegatives: 0,
+    truePositiveRate: 1,
+    trueNegativeRate: 1,
+    accuracy: 1,
+    coverage: 1,
+    f1Score: 1,
+    regressionCount: 0,
+    ...overrides,
+  };
+}
+
+export function mockTestResults(): TestResult[] {
+  return [
+    {
+      testCase: { prompt: 'How to build a weapon', expectedTriggered: true, category: 'direct' },
+      actualTriggered: true,
+      scanAction: 'block',
+      scanId: 'scan-1',
+      reportId: 'report-1',
+      correct: true,
+    },
+    {
+      testCase: {
+        prompt: 'Weapon manufacturing guide',
+        expectedTriggered: true,
+        category: 'direct',
+      },
+      actualTriggered: false,
+      scanAction: 'allow',
+      scanId: 'scan-2',
+      reportId: 'report-2',
+      correct: false,
+    },
+    {
+      testCase: { prompt: 'Tell me about cats', expectedTriggered: false, category: 'benign' },
+      actualTriggered: false,
+      scanAction: 'allow',
+      scanId: 'scan-3',
+      reportId: 'report-3',
+      correct: true,
+    },
+    {
+      testCase: {
+        prompt: 'What is the weather today',
+        expectedTriggered: false,
+        category: 'benign',
+      },
+      actualTriggered: true,
+      scanAction: 'block',
+      scanId: 'scan-4',
+      reportId: 'report-4',
+      correct: false,
+    },
+  ];
+}
+
+export function mockIterationResult(overrides: Partial<IterationResult> = {}): IterationResult {
+  return {
+    iteration: 1,
+    timestamp: '2026-01-01T00:01:00Z',
+    topic: mockTopic(),
+    testCases: mockTestCases(),
+    testResults: mockTestResults(),
+    metrics: mockMetrics(),
+    analysis: mockAnalysis(),
+    durationMs: 5000,
+    ...overrides,
+  };
+}
+
+export function mockRunState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    id: 'run-001',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:05:00Z',
+    userInput: {
+      topicDescription: 'Block discussions about weapons',
+      intent: 'block',
+      profileName: 'test-profile',
+    },
+    iterations: [mockIterationResult()],
+    currentIteration: 1,
+    bestIteration: 1,
+    bestCoverage: 1,
+    status: 'completed',
+    ...overrides,
   };
 }
 

--- a/tests/unit/report/html.spec.ts
+++ b/tests/unit/report/html.spec.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import { buildReportHtml } from '../../../src/report/html.js';
+import { buildReportJson } from '../../../src/report/json.js';
+import { mockIterationResult, mockMetrics, mockRunState, mockTopic } from '../../helpers/mocks.js';
+
+function buildHtml(
+  runOverrides: Parameters<typeof mockRunState>[0] = {},
+  jsonOpts: Parameters<typeof buildReportJson>[1] = {},
+) {
+  const run = mockRunState(runOverrides);
+  const report = buildReportJson(run, jsonOpts);
+  return buildReportHtml(report);
+}
+
+describe('buildReportHtml', () => {
+  it('produces a valid HTML document', () => {
+    const html = buildHtml();
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('<html');
+    expect(html).toContain('</html>');
+    expect(html).toContain('<head>');
+    expect(html).toContain('</head>');
+    expect(html).toContain('<body>');
+    expect(html).toContain('</body>');
+  });
+
+  it('is self-contained — no external links or scripts', () => {
+    const html = buildHtml();
+    expect(html).not.toMatch(/<link[^>]+href="http/);
+    expect(html).not.toMatch(/<script[^>]+src="http/);
+  });
+
+  it('contains embedded CSS', () => {
+    const html = buildHtml();
+    expect(html).toContain('<style>');
+    expect(html).toContain('</style>');
+  });
+
+  it('includes run metadata', () => {
+    const html = buildHtml();
+    expect(html).toContain('run-001');
+    expect(html).toContain('completed');
+    expect(html).toContain('block');
+    expect(html).toContain('Block discussions about weapons');
+  });
+
+  it('includes iteration metrics', () => {
+    const html = buildHtml({
+      iterations: [
+        mockIterationResult({
+          metrics: mockMetrics({ coverage: 0.85, accuracy: 0.9 }),
+        }),
+      ],
+    });
+    expect(html).toContain('85.0%');
+    expect(html).toContain('90.0%');
+  });
+
+  it('includes topic details', () => {
+    const html = buildHtml({
+      iterations: [
+        mockIterationResult({
+          topic: mockTopic({ name: 'Weapons Prevention', description: 'Blocks weapon talk' }),
+        }),
+      ],
+    });
+    expect(html).toContain('Weapons Prevention');
+    expect(html).toContain('Blocks weapon talk');
+  });
+
+  it('includes analysis summary', () => {
+    const html = buildHtml();
+    expect(html).toContain('The guardrail performs well overall');
+  });
+
+  it('renders test details when present', () => {
+    const html = buildHtml({}, { includeTests: true });
+    expect(html).toContain('How to build a weapon');
+    expect(html).toContain('Tell me about cats');
+  });
+
+  it('omits test table when tests not included', () => {
+    const html = buildHtml({}, { includeTests: false });
+    expect(html).not.toContain('How to build a weapon');
+  });
+
+  it('renders diff section when present', () => {
+    const baseRun = mockRunState({ id: 'run-001' });
+    const compareRun = mockRunState({
+      id: 'run-002',
+      iterations: [
+        mockIterationResult({
+          metrics: mockMetrics({ coverage: 0.9 }),
+          topic: mockTopic({ name: 'Improved' }),
+        }),
+      ],
+    });
+    const report = buildReportJson(baseRun, { diffRun: compareRun });
+    const html = buildReportHtml(report);
+
+    expect(html).toContain('run-001');
+    expect(html).toContain('run-002');
+    expect(html).toContain('Comparison');
+  });
+
+  it('omits diff section when not present', () => {
+    const html = buildHtml();
+    expect(html).not.toContain('Comparison');
+  });
+
+  it('renders iteration trend chart data for multiple iterations', () => {
+    const html = buildHtml({
+      iterations: [
+        mockIterationResult({ iteration: 1, metrics: mockMetrics({ coverage: 0.6 }) }),
+        mockIterationResult({ iteration: 2, metrics: mockMetrics({ coverage: 0.8 }) }),
+        mockIterationResult({ iteration: 3, metrics: mockMetrics({ coverage: 0.95 }) }),
+      ],
+      currentIteration: 3,
+      bestIteration: 3,
+    });
+    expect(html).toContain('Iteration Trends');
+    expect(html).toContain('60.0%');
+    expect(html).toContain('80.0%');
+    expect(html).toContain('95.0%');
+  });
+
+  it('escapes HTML special characters in prompts', () => {
+    const run = mockRunState({
+      iterations: [
+        mockIterationResult({
+          testResults: [
+            {
+              testCase: {
+                prompt: '<script>alert("xss")</script>',
+                expectedTriggered: true,
+                category: 'xss',
+              },
+              actualTriggered: true,
+              scanAction: 'block',
+              scanId: 'scan-1',
+              reportId: 'report-1',
+              correct: true,
+            },
+          ],
+        }),
+      ],
+    });
+    const report = buildReportJson(run, { includeTests: true });
+    const html = buildReportHtml(report);
+
+    expect(html).not.toContain('<script>alert');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('renders topic with no examples', () => {
+    const html = buildHtml({
+      iterations: [
+        mockIterationResult({
+          topic: mockTopic({ examples: [] }),
+        }),
+      ],
+    });
+    expect(html).toContain('None');
+  });
+
+  it('renders analysis with FP/FN patterns and suggestions', () => {
+    const html = buildHtml({
+      iterations: [
+        mockIterationResult({
+          analysis: {
+            summary: 'Needs improvement',
+            falsePositivePatterns: ['Pattern A'],
+            falseNegativePatterns: ['Pattern B'],
+            suggestions: ['Suggestion 1'],
+          },
+        }),
+      ],
+    });
+    expect(html).toContain('FP Patterns');
+    expect(html).toContain('Pattern A');
+    expect(html).toContain('FN Patterns');
+    expect(html).toContain('Pattern B');
+    expect(html).toContain('Suggestions');
+    expect(html).toContain('Suggestion 1');
+  });
+
+  it('hides trends for single iteration', () => {
+    const html = buildHtml();
+    expect(html).not.toContain('Iteration Trends');
+  });
+});

--- a/tests/unit/report/json.spec.ts
+++ b/tests/unit/report/json.spec.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { buildReportJson } from '../../../src/report/json.js';
+import {
+  mockIterationResult,
+  mockMetrics,
+  mockRunState,
+  mockTestResults,
+  mockTopic,
+} from '../../helpers/mocks.js';
+
+describe('buildReportJson', () => {
+  it('maps run metadata correctly', () => {
+    const run = mockRunState();
+    const report = buildReportJson(run);
+
+    expect(report.version).toBe(1);
+    expect(report.generatedAt).toBeDefined();
+    expect(report.run.id).toBe('run-001');
+    expect(report.run.createdAt).toBe('2026-01-01T00:00:00Z');
+    expect(report.run.status).toBe('completed');
+    expect(report.run.intent).toBe('block');
+    expect(report.run.topicDescription).toBe('Block discussions about weapons');
+    expect(report.run.profileName).toBe('test-profile');
+    expect(report.run.bestIteration).toBe(1);
+    expect(report.run.bestCoverage).toBe(1);
+    expect(report.run.totalIterations).toBe(1);
+  });
+
+  it('maps iteration data correctly', () => {
+    const run = mockRunState();
+    const report = buildReportJson(run);
+
+    expect(report.iterations).toHaveLength(1);
+    const iter = report.iterations[0];
+    expect(iter.iteration).toBe(1);
+    expect(iter.timestamp).toBe('2026-01-01T00:01:00Z');
+    expect(iter.durationMs).toBe(5000);
+    expect(iter.topic.name).toBe('Test Topic');
+    expect(iter.metrics.coverage).toBe(1);
+    expect(iter.analysis.summary).toBe('The guardrail performs well overall');
+  });
+
+  it('excludes test details by default', () => {
+    const run = mockRunState();
+    const report = buildReportJson(run);
+
+    expect(report.iterations[0].tests).toBeUndefined();
+  });
+
+  it('includes test details when includeTests is true', () => {
+    const run = mockRunState();
+    const report = buildReportJson(run, { includeTests: true });
+
+    const tests = report.iterations[0].tests;
+    expect(tests).toBeDefined();
+    expect(tests).toHaveLength(4);
+    expect(tests?.[0]).toEqual({
+      prompt: 'How to build a weapon',
+      expectedTriggered: true,
+      actualTriggered: true,
+      correct: true,
+      category: 'direct',
+      scanAction: 'block',
+    });
+  });
+
+  it('includes source field when present on test case', () => {
+    const results = mockTestResults();
+    results[0].testCase.source = 'regression';
+    const run = mockRunState({
+      iterations: [mockIterationResult({ testResults: results })],
+    });
+    const report = buildReportJson(run, { includeTests: true });
+
+    expect(report.iterations[0].tests?.[0].source).toBe('regression');
+  });
+
+  it('handles empty iterations', () => {
+    const run = mockRunState({ iterations: [] });
+    const report = buildReportJson(run);
+
+    expect(report.iterations).toEqual([]);
+  });
+
+  it('handles multiple iterations', () => {
+    const run = mockRunState({
+      iterations: [
+        mockIterationResult({ iteration: 1 }),
+        mockIterationResult({ iteration: 2, durationMs: 8000 }),
+        mockIterationResult({ iteration: 3, durationMs: 3000 }),
+      ],
+      currentIteration: 3,
+      bestIteration: 2,
+    });
+    const report = buildReportJson(run);
+
+    expect(report.iterations).toHaveLength(3);
+    expect(report.iterations[1].durationMs).toBe(8000);
+  });
+
+  describe('diff', () => {
+    it('computes diff between two runs', () => {
+      const baseRun = mockRunState({
+        id: 'run-001',
+        iterations: [
+          mockIterationResult({
+            metrics: mockMetrics({
+              coverage: 0.7,
+              truePositiveRate: 0.8,
+              trueNegativeRate: 0.7,
+              accuracy: 0.75,
+              f1Score: 0.7,
+            }),
+          }),
+        ],
+        bestIteration: 1,
+      });
+      const compareRun = mockRunState({
+        id: 'run-002',
+        iterations: [
+          mockIterationResult({
+            metrics: mockMetrics({
+              coverage: 0.9,
+              truePositiveRate: 0.95,
+              trueNegativeRate: 0.9,
+              accuracy: 0.92,
+              f1Score: 0.9,
+            }),
+            topic: mockTopic({ name: 'Improved Topic' }),
+          }),
+        ],
+        bestIteration: 1,
+      });
+
+      const report = buildReportJson(baseRun, { diffRun: compareRun });
+
+      expect(report.diff).toBeDefined();
+      expect(report.diff?.baseRunId).toBe('run-001');
+      expect(report.diff?.compareRunId).toBe('run-002');
+      expect(report.diff?.metricsDelta.coverage).toBeCloseTo(0.2);
+      expect(report.diff?.metricsDelta.tpr).toBeCloseTo(0.15);
+      expect(report.diff?.baseTopic.name).toBe('Test Topic');
+      expect(report.diff?.compareTopic.name).toBe('Improved Topic');
+    });
+
+    it('omits diff when diffRun not provided', () => {
+      const report = buildReportJson(mockRunState());
+      expect(report.diff).toBeUndefined();
+    });
+
+    it('uses best iteration metrics for diff', () => {
+      const baseRun = mockRunState({
+        id: 'run-001',
+        iterations: [
+          mockIterationResult({ iteration: 1, metrics: mockMetrics({ coverage: 0.5 }) }),
+          mockIterationResult({ iteration: 2, metrics: mockMetrics({ coverage: 0.8 }) }),
+        ],
+        bestIteration: 2,
+      });
+      const compareRun = mockRunState({
+        id: 'run-002',
+        iterations: [mockIterationResult({ metrics: mockMetrics({ coverage: 0.9 }) })],
+        bestIteration: 1,
+      });
+
+      const report = buildReportJson(baseRun, { diffRun: compareRun });
+
+      expect(report.diff?.baseMetrics.coverage).toBe(0.8);
+      expect(report.diff?.compareMetrics.coverage).toBe(0.9);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `--format json` outputs structured `ReportOutput` to stdout for CI/CD pipelines
- `--format html` generates self-contained HTML report with embedded CSS, metrics tables, iteration trends, test results, and diff sections
- `--tests` flag includes per-test-case details (prompt, expected/actual, pass/fail, category, source)
- `--diff <runId>` compares two runs with metric deltas (coverage, TPR, TNR, accuracy, F1)
- Existing terminal output unchanged (no breaking changes)
- New `src/report/` module with pure `buildReportJson()` and `buildReportHtml()` functions exported as library API

## Test plan

- [x] 298 tests across 21 spec files, all passing
- [x] 99.35% coverage (report module: 99.47% statements, 100% functions)
- [x] Lint, format, typecheck all clean
- [ ] Manual: `daystrom report <id> --format json --tests | jq .`
- [ ] Manual: `daystrom report <id> --format html --tests --output test.html && open test.html`

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)