### PR TITLE
feat: red team CRUD + SDK v0.6.0 upgrade

### DIFF
--- a/.changeset/0001-redteam-crud-v060.md
+++ b/.changeset/0001-redteam-crud-v060.md
@@ -1,0 +1,5 @@
+---
+"@cdot65/daystrom": minor
+---
+
+Add full red team CRUD operations: target create/get/update/delete with connection validation, prompt set management (get/update/archive/version-info/CSV upload/download), individual prompt CRUD, and property name/value management. Upgrades @cdot65/prisma-airs-sdk from v0.4.0 to v0.6.0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ src/
 │   │   ├── report.ts      # View run results by ID
 │   │   ├── list.ts        # List all saved runs
 │   │   ├── audit.ts       # Profile-level multi-topic evaluation
-│   │   └── redteam.ts     # Red team scan operations (7 subcommands)
+│   │   └── redteam.ts     # Red team operations (scan, targets CRUD, prompt-sets CRUD, prompts CRUD, properties)
 │   ├── prompts.ts         # Inquirer interactive input collection
 │   └── renderer.ts        # Terminal output (chalk)
 ├── config/
@@ -135,14 +135,16 @@ tests/
 - Guardrail-level `action` must always be `'block'` to enforce violations
 - Topics can't be deleted while referenced by any profile revision
 
-### Red Team (`src/airs/redteam.ts`)
-- `SdkRedTeamService` wraps `RedTeamClient` for scan CRUD, polling, reports
+### Red Team (`src/airs/redteam.ts`, `src/airs/promptsets.ts`)
+- `SdkRedTeamService` wraps `RedTeamClient` for scan CRUD, polling, reports, **target CRUD**
+- `SdkPromptSetService` wraps `RedTeamClient.customAttacks` for prompt set CRUD, prompt CRUD, CSV upload, properties
 - 3 scan types: STATIC (attack library), DYNAMIC (agent-driven), CUSTOM (prompt sets)
 - `custom_prompt_sets` must be an array of UUID strings (not `{ uuid }` objects) — AIRS API returns 422 otherwise
 - ASR/score/threatRate from AIRS API are percentages (0-100), not ratios — render directly, don't multiply by 100
 - `listCustomAttacks()` uses `customAttackReports.listCustomAttacks()` for prompt-level results on CUSTOM scans
 - `waitForCompletion()` polls with configurable interval, throws on FAILED
-- CLI: `daystrom redteam {scan,status,report,list,targets,categories,abort}`
+- Target create/update accept `{ validate: true }` to validate connection before saving (SDK v0.6.0)
+- CLI subcommand groups: `targets {list,get,create,update,delete,probe,profile,update-profile}`, `prompt-sets {list,get,create,update,archive,download,upload}`, `prompts {list,get,add,update,delete}`, `properties {list,create,values,add-value}`
 
 ### LLM Service (`src/llm/`)
 - 6 providers: `claude-api` (default), `claude-vertex`, `claude-bedrock`, `gemini-api`, `gemini-vertex`, `gemini-bedrock`

--- a/docs/features/red-team.md
+++ b/docs/features/red-team.md
@@ -4,13 +4,16 @@ Daystrom integrates with Palo Alto Prisma AIRS AI Red Team to run adversarial sc
 
 ## Overview
 
-The `daystrom redteam` command group provides full access to Red Team scan operations:
+The `daystrom redteam` command group provides full access to Red Team operations:
 
 - **Scan** — launch static, dynamic, or custom prompt set scans
 - **Status** — monitor running scans
 - **Report** — view results with severity breakdowns and attack details
 - **List** — browse recent scans
-- **Targets** — list configured red team targets
+- **Targets** — full CRUD on red team targets (create, get, update, delete, probe, profile)
+- **Prompt Sets** — manage custom prompt sets (create, get, update, archive, upload CSV, download template)
+- **Prompts** — manage individual prompts within sets (add, list, get, update, delete)
+- **Properties** — manage custom attack property names and values
 - **Categories** — list available attack categories
 - **Abort** — stop a running scan
 
@@ -24,10 +27,60 @@ The `daystrom redteam` command group provides full access to Red Team scan opera
 
 ## Workflow
 
-### 1. Check available targets
+### 1. Manage targets
 
 ```bash
-daystrom redteam targets
+# List all targets
+daystrom redteam targets list
+
+# Get target details
+daystrom redteam targets get <uuid>
+
+# Create a target from JSON config file
+daystrom redteam targets create --config target.json
+
+# Create with connection validation
+daystrom redteam targets create --config target.json --validate
+
+# Update a target
+daystrom redteam targets update <uuid> --config updates.json
+
+# Update with connection validation
+daystrom redteam targets update <uuid> --config updates.json --validate
+
+# Delete a target
+daystrom redteam targets delete <uuid>
+
+# Probe a target connection (test without saving)
+daystrom redteam targets probe --config connection.json
+
+# View target profile
+daystrom redteam targets profile <uuid>
+
+# Update target profile
+daystrom redteam targets update-profile <uuid> --config profile.json
+```
+
+**Example `target.json`:**
+```json
+{
+  "name": "My Chatbot",
+  "target_type": "REST",
+  "connection_params": {
+    "api_endpoint": "https://api.example.com/chat",
+    "request_headers": { "Authorization": "Bearer token" },
+    "request_json": { "message": "{prompt}" },
+    "response_key": "response"
+  },
+  "background": {
+    "industry": "finance",
+    "use_case": "customer support"
+  },
+  "metadata": {
+    "multi_turn": false,
+    "rate_limit": 10
+  }
+}
 ```
 
 ### 2. Browse attack categories (for STATIC scans)
@@ -62,9 +115,9 @@ daystrom redteam scan --target <uuid> --name "Async Scan" --no-wait
 ```
 
 !!! tip "Finding prompt set UUIDs"
+    Use `daystrom redteam prompt-sets list` to find prompt set UUIDs.
     Prompt sets created by `daystrom generate --create-prompt-set` emit
-    the UUID in the `promptset:created` event. You can also list prompt
-    sets via the SDK's `SdkPromptSetService.listPromptSets()`.
+    the UUID in the `promptset:created` event.
 
 ### 4. Check status
 
@@ -109,6 +162,69 @@ daystrom redteam list --target <uuid> --limit 20
 daystrom redteam abort <jobId>
 ```
 
+## Prompt Set Management
+
+```bash
+# List all prompt sets
+daystrom redteam prompt-sets list
+
+# Get prompt set details + version info
+daystrom redteam prompt-sets get <uuid>
+
+# Create a prompt set
+daystrom redteam prompt-sets create --name "My Set" --description "Test prompts"
+
+# Update a prompt set
+daystrom redteam prompt-sets update <uuid> --name "New Name"
+
+# Archive/unarchive
+daystrom redteam prompt-sets archive <uuid>
+daystrom redteam prompt-sets archive <uuid> --unarchive
+
+# Download CSV template
+daystrom redteam prompt-sets download <uuid> --output template.csv
+
+# Upload CSV prompts
+daystrom redteam prompt-sets upload <uuid> prompts.csv
+```
+
+## Individual Prompt Management
+
+```bash
+# List prompts in a set
+daystrom redteam prompts list <setUuid>
+
+# Get prompt details
+daystrom redteam prompts get <setUuid> <promptUuid>
+
+# Add a prompt
+daystrom redteam prompts add <setUuid> --prompt "Test prompt" --goal "Should trigger"
+
+# Update a prompt
+daystrom redteam prompts update <setUuid> <promptUuid> --prompt "Updated text"
+
+# Delete a prompt
+daystrom redteam prompts delete <setUuid> <promptUuid>
+```
+
+## Property Management
+
+Custom attack properties let you tag and categorize prompts.
+
+```bash
+# List property names
+daystrom redteam properties list
+
+# Create a property name
+daystrom redteam properties create --name "category"
+
+# List values for a property
+daystrom redteam properties values category
+
+# Add a property value
+daystrom redteam properties add-value --name "category" --value "security"
+```
+
 ## Authentication
 
 Red Team operations reuse the same OAuth2 credentials as topic management:
@@ -125,10 +241,10 @@ Optional overrides for dedicated red team endpoints:
 
 ## Library API
 
-The `SdkRedTeamService` class is exported for programmatic use:
+The `SdkRedTeamService` and `SdkPromptSetService` classes are exported for programmatic use:
 
 ```typescript
-import { SdkRedTeamService } from '@cdot65/daystrom';
+import { SdkRedTeamService, SdkPromptSetService } from '@cdot65/daystrom';
 
 const redteam = new SdkRedTeamService({
   clientId: process.env.PANW_MGMT_CLIENT_ID,
@@ -136,14 +252,32 @@ const redteam = new SdkRedTeamService({
   tsgId: process.env.PANW_MGMT_TSG_ID,
 });
 
-const targets = await redteam.listTargets();
+// Target CRUD
+const target = await redteam.createTarget({
+  name: 'My Target',
+  target_type: 'REST',
+  connection_params: { api_endpoint: 'https://api.example.com' },
+}, { validate: true });
+
+// Scans
 const job = await redteam.createScan({
   name: 'API Scan',
-  targetUuid: targets[0].uuid,
+  targetUuid: target.uuid,
   jobType: 'STATIC',
 });
 const completed = await redteam.waitForCompletion(job.uuid, (progress) => {
   console.log(`${progress.status}: ${progress.completed}/${progress.total}`);
 });
 const report = await redteam.getStaticReport(completed.uuid);
+
+// Prompt set management
+const promptSets = new SdkPromptSetService({
+  clientId: process.env.PANW_MGMT_CLIENT_ID,
+  clientSecret: process.env.PANW_MGMT_CLIENT_SECRET,
+  tsgId: process.env.PANW_MGMT_TSG_ID,
+});
+
+const ps = await promptSets.createPromptSet('My Set', 'Description');
+await promptSets.addPrompt(ps.uuid, 'Test prompt', 'Should trigger');
+await promptSets.uploadPromptsCsv(ps.uuid, new Blob(['prompt,goal\n"test","goal"']));
 ```

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -205,32 +205,19 @@ daystrom redteam scan [options]
 # Static scan with all categories
 daystrom redteam scan --target <uuid> --name "Full Scan"
 
-# Static scan — specific categories only
-daystrom redteam scan --target <uuid> --name "PI Scan" \
-  --categories '{"prompt_injection": {}}'
-
 # Custom scan with a daystrom-generated prompt set
 daystrom redteam scan \
-  --target bff3b6ca-8be7-441c-823e-c36f1a61d41e \
-  --name "Explosives Topic Validation" \
-  --type CUSTOM \
-  --prompt-sets 7829805d-6479-4ce1-866b-2bff66a3c766
-
-# Submit and return immediately (don't wait for completion)
-daystrom redteam scan --target <uuid> --name "Async" --no-wait
+  --target <uuid> --name "Topic Validation" \
+  --type CUSTOM --prompt-sets <uuid1>,<uuid2>
 ```
 
 ### redteam status
-
-Check scan status.
 
 ```bash
 daystrom redteam status <jobId>
 ```
 
 ### redteam report
-
-View scan report.
 
 ```bash
 daystrom redteam report <jobId> [options]
@@ -243,8 +230,6 @@ daystrom redteam report <jobId> [options]
 | `--limit <n>` | `20` | Max attacks to show |
 
 ### redteam list
-
-List recent scans.
 
 ```bash
 daystrom redteam list [options]
@@ -259,21 +244,87 @@ daystrom redteam list [options]
 
 ### redteam targets
 
-List configured red team targets.
+Manage red team targets — full CRUD with connection validation.
 
 ```bash
-daystrom redteam targets
+daystrom redteam targets list                          # List all targets
+daystrom redteam targets get <uuid>                    # Get target details
+daystrom redteam targets create --config target.json   # Create from JSON file
+daystrom redteam targets create --config t.json --validate  # Create + validate connection
+daystrom redteam targets update <uuid> --config u.json # Update target
+daystrom redteam targets update <uuid> --config u.json --validate
+daystrom redteam targets delete <uuid>                 # Delete target
+daystrom redteam targets probe --config conn.json      # Test connection
+daystrom redteam targets profile <uuid>                # View target profile
+daystrom redteam targets update-profile <uuid> --config p.json
 ```
+
+| Subcommand | Flags |
+|------------|-------|
+| `list` | — |
+| `get <uuid>` | — |
+| `create` | `--config <path>` (required), `--validate` |
+| `update <uuid>` | `--config <path>` (required), `--validate` |
+| `delete <uuid>` | — |
+| `probe` | `--config <path>` (required) |
+| `profile <uuid>` | — |
+| `update-profile <uuid>` | `--config <path>` (required) |
 
 ### redteam prompt-sets
 
-List custom prompt sets with their UUIDs.
+Manage custom prompt sets — CRUD, CSV upload/download, archive.
 
 ```bash
-daystrom redteam prompt-sets
+daystrom redteam prompt-sets list                          # List all sets
+daystrom redteam prompt-sets get <uuid>                    # Details + version info
+daystrom redteam prompt-sets create --name "My Set"        # Create
+daystrom redteam prompt-sets update <uuid> --name "New"    # Update
+daystrom redteam prompt-sets archive <uuid>                # Archive
+daystrom redteam prompt-sets archive <uuid> --unarchive    # Unarchive
+daystrom redteam prompt-sets download <uuid>               # Download CSV template
+daystrom redteam prompt-sets upload <uuid> prompts.csv     # Upload CSV
 ```
 
-Use this to find the UUID of a prompt set created by `--create-prompt-set` during `daystrom generate`.
+| Subcommand | Flags |
+|------------|-------|
+| `list` | — |
+| `get <uuid>` | — |
+| `create` | `--name` (required), `--description` |
+| `update <uuid>` | `--name`, `--description` |
+| `archive <uuid>` | `--unarchive` |
+| `download <uuid>` | `--output <path>` |
+| `upload <uuid> <file>` | — |
+
+### redteam prompts
+
+Manage individual prompts within prompt sets.
+
+```bash
+daystrom redteam prompts list <setUuid>                        # List prompts
+daystrom redteam prompts get <setUuid> <promptUuid>            # Get prompt
+daystrom redteam prompts add <setUuid> --prompt "text"         # Add prompt
+daystrom redteam prompts update <setUuid> <promptUuid> --prompt "new"  # Update
+daystrom redteam prompts delete <setUuid> <promptUuid>         # Delete
+```
+
+| Subcommand | Flags |
+|------------|-------|
+| `list <setUuid>` | `--limit <n>` (default 50) |
+| `get <setUuid> <promptUuid>` | — |
+| `add <setUuid>` | `--prompt` (required), `--goal` |
+| `update <setUuid> <promptUuid>` | `--prompt`, `--goal` |
+| `delete <setUuid> <promptUuid>` | — |
+
+### redteam properties
+
+Manage custom attack property names and values.
+
+```bash
+daystrom redteam properties list                               # List names
+daystrom redteam properties create --name "category"           # Create name
+daystrom redteam properties values category                    # List values
+daystrom redteam properties add-value --name cat --value sec   # Add value
+```
 
 ### redteam categories
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Automated Prisma AIRS custom topic guardrail generator with iterative refinement",
   "type": "module",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.14.4",
-    "@cdot65/prisma-airs-sdk": "^0.4.0",
+    "@cdot65/prisma-airs-sdk": "^0.6.0",
     "@inquirer/prompts": "^8.3.0",
     "@langchain/anthropic": "^1.3.21",
     "@langchain/aws": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.14.4
         version: 0.14.4(zod@3.25.76)
       '@cdot65/prisma-airs-sdk':
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.0(@types/node@22.19.13)
@@ -314,8 +314,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cdot65/prisma-airs-sdk@0.4.0':
-    resolution: {integrity: sha512-5ibkdw24wHK7ysnA5he0LTC65LdyqlYvpDz7IGGHsm6LIdMorFxdTC2XxVRizG2dx8nsr7Til/gCAU8/mY79hQ==}
+  '@cdot65/prisma-airs-sdk@0.6.0':
+    resolution: {integrity: sha512-QsaeEK4SMsUZAKutX/LB0bqxN6Buf6JA2QYFh3CCG3GicKMtGerNdKSSBk601yIaU9iMQlTJkt6MpH+4yBAfjA==}
     engines: {node: '>=18'}
 
   '@cfworker/json-schema@4.1.1':
@@ -2434,7 +2434,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.5':
     optional: true
 
-  '@cdot65/prisma-airs-sdk@0.4.0':
+  '@cdot65/prisma-airs-sdk@0.6.0':
     dependencies:
       zod: 3.25.76
 

--- a/src/airs/promptsets.ts
+++ b/src/airs/promptsets.ts
@@ -1,5 +1,36 @@
 import { RedTeamClient, type RedTeamClientOptions } from '@cdot65/prisma-airs-sdk';
-import type { PromptSetService } from './types.js';
+import type {
+  PromptDetail,
+  PromptSetDetail,
+  PromptSetService,
+  PromptSetVersionInfo,
+  PropertyName,
+  PropertyValue,
+} from './types.js';
+
+/** Normalize SDK prompt set response to PromptSetDetail. */
+function normalizePromptSet(raw: Record<string, unknown>): PromptSetDetail {
+  return {
+    uuid: raw.uuid as string,
+    name: raw.name as string,
+    active: raw.active as boolean,
+    archive: raw.archive as boolean,
+    description: raw.description as string | undefined,
+    createdAt: raw.created_at as string | undefined,
+    updatedAt: raw.updated_at as string | undefined,
+  };
+}
+
+/** Normalize SDK prompt response to PromptDetail. */
+function normalizePrompt(raw: Record<string, unknown>): PromptDetail {
+  return {
+    uuid: raw.uuid as string,
+    prompt: raw.prompt as string,
+    goal: raw.goal as string | undefined,
+    active: raw.active as boolean,
+    promptSetId: raw.prompt_set_id as string,
+  };
+}
 
 /**
  * Wraps the SDK's RedTeamClient.customAttacks to implement PromptSetService.
@@ -43,5 +74,94 @@ export class SdkPromptSetService implements PromptSetService {
       name: ps.name,
       active: ps.active,
     }));
+  }
+
+  async getPromptSet(uuid: string): Promise<PromptSetDetail> {
+    const response = await this.client.customAttacks.getPromptSet(uuid);
+    return normalizePromptSet(response as unknown as Record<string, unknown>);
+  }
+
+  async updatePromptSet(
+    uuid: string,
+    request: { name?: string; description?: string },
+  ): Promise<PromptSetDetail> {
+    const response = await this.client.customAttacks.updatePromptSet(uuid, request as never);
+    return normalizePromptSet(response as unknown as Record<string, unknown>);
+  }
+
+  async archivePromptSet(uuid: string, archive: boolean): Promise<void> {
+    await this.client.customAttacks.archivePromptSet(uuid, { archive } as never);
+  }
+
+  async getPromptSetVersionInfo(uuid: string): Promise<PromptSetVersionInfo> {
+    const response = await this.client.customAttacks.getPromptSetVersionInfo(uuid);
+    const raw = response as unknown as Record<string, unknown>;
+    return {
+      uuid: raw.uuid as string,
+      version: raw.version as number,
+      stats: raw.stats as PromptSetVersionInfo['stats'],
+    };
+  }
+
+  async downloadTemplate(uuid: string): Promise<string> {
+    const response = await this.client.customAttacks.downloadTemplate(uuid);
+    return response as unknown as string;
+  }
+
+  async uploadPromptsCsv(uuid: string, file: Blob): Promise<{ message: string; status: number }> {
+    const response = await this.client.customAttacks.uploadPromptsCsv(uuid, file);
+    return response as unknown as { message: string; status: number };
+  }
+
+  async listPrompts(
+    setUuid: string,
+    opts?: { limit?: number; skip?: number },
+  ): Promise<PromptDetail[]> {
+    const response = await this.client.customAttacks.listPrompts(setUuid, opts);
+    return (
+      (response as unknown as Record<string, unknown>).data as Array<Record<string, unknown>>
+    ).map(normalizePrompt);
+  }
+
+  async getPrompt(setUuid: string, promptUuid: string): Promise<PromptDetail> {
+    const response = await this.client.customAttacks.getPrompt(setUuid, promptUuid);
+    return normalizePrompt(response as unknown as Record<string, unknown>);
+  }
+
+  async updatePrompt(
+    setUuid: string,
+    promptUuid: string,
+    request: { prompt?: string; goal?: string },
+  ): Promise<PromptDetail> {
+    const response = await this.client.customAttacks.updatePrompt(
+      setUuid,
+      promptUuid,
+      request as never,
+    );
+    return normalizePrompt(response as unknown as Record<string, unknown>);
+  }
+
+  async deletePrompt(setUuid: string, promptUuid: string): Promise<void> {
+    await this.client.customAttacks.deletePrompt(setUuid, promptUuid);
+  }
+
+  async getPropertyNames(): Promise<PropertyName[]> {
+    const response = await this.client.customAttacks.getPropertyNames();
+    return response as unknown as PropertyName[];
+  }
+
+  async createPropertyName(name: string): Promise<PropertyName> {
+    const response = await this.client.customAttacks.createPropertyName({ name } as never);
+    return response as unknown as PropertyName;
+  }
+
+  async getPropertyValues(name: string): Promise<PropertyValue[]> {
+    const response = await this.client.customAttacks.getPropertyValues(name);
+    return response as unknown as PropertyValue[];
+  }
+
+  async createPropertyValue(name: string, value: string): Promise<PropertyValue> {
+    const response = await this.client.customAttacks.createPropertyValue({ name, value } as never);
+    return response as unknown as PropertyValue;
   }
 }

--- a/src/airs/redteam.ts
+++ b/src/airs/redteam.ts
@@ -8,6 +8,10 @@ import type {
   RedTeamService,
   RedTeamStaticReport,
   RedTeamTarget,
+  RedTeamTargetCreateRequest,
+  RedTeamTargetDetail,
+  RedTeamTargetUpdateRequest,
+  TargetOperationOptions,
 } from './types.js';
 
 const TERMINAL_STATUSES = new Set(['COMPLETED', 'PARTIALLY_COMPLETE', 'FAILED', 'ABORTED']);
@@ -27,6 +31,21 @@ function normalizeJob(raw: Record<string, unknown>): RedTeamJob {
     total: raw.total as number | null | undefined,
     completed: raw.completed as number | null | undefined,
     createdAt: raw.created_at as string | null | undefined,
+  };
+}
+
+/** Normalize an SDK target response into a RedTeamTargetDetail. */
+function normalizeTargetDetail(raw: Record<string, unknown>): RedTeamTargetDetail {
+  return {
+    uuid: raw.uuid as string,
+    name: raw.name as string,
+    status: raw.status as string,
+    targetType: raw.target_type as string | undefined,
+    active: raw.active as boolean,
+    connectionParams: raw.connection_params as Record<string, unknown> | undefined,
+    background: raw.background as RedTeamTargetDetail['background'],
+    additionalContext: raw.additional_context as RedTeamTargetDetail['additionalContext'],
+    metadata: raw.metadata as RedTeamTargetDetail['metadata'],
   };
 }
 
@@ -50,6 +69,50 @@ export class SdkRedTeamService implements RedTeamService {
       targetType: t.target_type as string | undefined,
       active: t.active as boolean,
     }));
+  }
+
+  async getTarget(uuid: string): Promise<RedTeamTargetDetail> {
+    const response = await this.client.targets.get(uuid);
+    return normalizeTargetDetail(response as unknown as Record<string, unknown>);
+  }
+
+  async createTarget(
+    request: RedTeamTargetCreateRequest,
+    opts?: TargetOperationOptions,
+  ): Promise<RedTeamTargetDetail> {
+    const response = await this.client.targets.create(request as never, opts);
+    return normalizeTargetDetail(response as unknown as Record<string, unknown>);
+  }
+
+  async updateTarget(
+    uuid: string,
+    request: RedTeamTargetUpdateRequest,
+    opts?: TargetOperationOptions,
+  ): Promise<RedTeamTargetDetail> {
+    const response = await this.client.targets.update(uuid, request as never, opts);
+    return normalizeTargetDetail(response as unknown as Record<string, unknown>);
+  }
+
+  async deleteTarget(uuid: string): Promise<void> {
+    await this.client.targets.delete(uuid);
+  }
+
+  async probeTarget(request: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const response = await this.client.targets.probe(request as never);
+    return response as unknown as Record<string, unknown>;
+  }
+
+  async getTargetProfile(uuid: string): Promise<Record<string, unknown>> {
+    const response = await this.client.targets.getProfile(uuid);
+    return response as unknown as Record<string, unknown>;
+  }
+
+  async updateTargetProfile(
+    uuid: string,
+    request: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.client.targets.updateProfile(uuid, request as never);
+    return response as unknown as Record<string, unknown>;
   }
 
   async createScan(request: {

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -57,6 +57,41 @@ export interface PromptSetService {
   ): Promise<{ uuid: string; prompt: string }>;
   /** List all custom prompt sets. */
   listPromptSets(): Promise<Array<{ uuid: string; name: string; active: boolean }>>;
+  /** Get prompt set details. */
+  getPromptSet(uuid: string): Promise<PromptSetDetail>;
+  /** Update prompt set name/description. */
+  updatePromptSet(
+    uuid: string,
+    request: { name?: string; description?: string },
+  ): Promise<PromptSetDetail>;
+  /** Archive or unarchive a prompt set. */
+  archivePromptSet(uuid: string, archive: boolean): Promise<void>;
+  /** Get prompt set version info with stats. */
+  getPromptSetVersionInfo(uuid: string): Promise<PromptSetVersionInfo>;
+  /** Download CSV template for a prompt set. */
+  downloadTemplate(uuid: string): Promise<string>;
+  /** Upload CSV file to a prompt set. */
+  uploadPromptsCsv(uuid: string, file: Blob): Promise<{ message: string; status: number }>;
+  /** List prompts in a prompt set. */
+  listPrompts(setUuid: string, opts?: { limit?: number; skip?: number }): Promise<PromptDetail[]>;
+  /** Get a single prompt. */
+  getPrompt(setUuid: string, promptUuid: string): Promise<PromptDetail>;
+  /** Update a prompt. */
+  updatePrompt(
+    setUuid: string,
+    promptUuid: string,
+    request: { prompt?: string; goal?: string },
+  ): Promise<PromptDetail>;
+  /** Delete a prompt. */
+  deletePrompt(setUuid: string, promptUuid: string): Promise<void>;
+  /** List property names. */
+  getPropertyNames(): Promise<PropertyName[]>;
+  /** Create a property name. */
+  createPropertyName(name: string): Promise<PropertyName>;
+  /** Get values for a property. */
+  getPropertyValues(name: string): Promise<PropertyValue[]>;
+  /** Create a property value. */
+  createPropertyValue(name: string, value: string): Promise<PropertyValue>;
 }
 
 // ---------------------------------------------------------------------------
@@ -85,6 +120,97 @@ export interface RedTeamTarget {
   status: string;
   targetType?: string;
   active: boolean;
+}
+
+/** Detailed target info with connection params and metadata. */
+export interface RedTeamTargetDetail extends RedTeamTarget {
+  connectionParams?: Record<string, unknown>;
+  background?: {
+    industry?: string | null;
+    use_case?: string | null;
+    competitors?: string[] | null;
+  };
+  additionalContext?: {
+    system_prompt?: string | null;
+    use_case_description?: string | null;
+    documents?: unknown[] | null;
+  };
+  metadata?: {
+    multi_turn?: boolean;
+    rate_limit?: number | null;
+    rate_limit_error_json?: Record<string, unknown> | null;
+    is_streaming_enabled?: boolean | null;
+    max_turns?: number | null;
+    api_endpoint_type?: string | null;
+    response_mode?: string | null;
+  };
+}
+
+/** Request to create a red team target. */
+export interface RedTeamTargetCreateRequest {
+  name: string;
+  target_type: string;
+  connection_params: Record<string, unknown>;
+  background?: Record<string, unknown>;
+  additional_context?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+/** Request to update a red team target. */
+export interface RedTeamTargetUpdateRequest {
+  name?: string;
+  target_type?: string;
+  connection_params?: Record<string, unknown>;
+  background?: Record<string, unknown>;
+  additional_context?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+/** Options for target create/update operations. */
+export interface TargetOperationOptions {
+  validate?: boolean;
+}
+
+/** Normalized prompt set detail. */
+export interface PromptSetDetail {
+  uuid: string;
+  name: string;
+  active: boolean;
+  archive: boolean;
+  description?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** Prompt set version info with stats. */
+export interface PromptSetVersionInfo {
+  uuid: string;
+  version: number;
+  stats: {
+    total: number;
+    active: number;
+    inactive: number;
+  };
+}
+
+/** Normalized individual prompt. */
+export interface PromptDetail {
+  uuid: string;
+  prompt: string;
+  goal?: string;
+  active: boolean;
+  promptSetId: string;
+}
+
+/** Property name entry. */
+export interface PropertyName {
+  name: string;
+}
+
+/** Property value entry. */
+export interface PropertyValue {
+  name: string;
+  value: string;
 }
 
 /** Normalized attack category with subcategories. */
@@ -161,6 +287,37 @@ export interface RedTeamCustomAttack {
 export interface RedTeamService {
   /** List configured red team targets. */
   listTargets(): Promise<RedTeamTarget[]>;
+
+  /** Get target details. */
+  getTarget(uuid: string): Promise<RedTeamTargetDetail>;
+
+  /** Create a red team target. */
+  createTarget(
+    request: RedTeamTargetCreateRequest,
+    opts?: TargetOperationOptions,
+  ): Promise<RedTeamTargetDetail>;
+
+  /** Update a red team target. */
+  updateTarget(
+    uuid: string,
+    request: RedTeamTargetUpdateRequest,
+    opts?: TargetOperationOptions,
+  ): Promise<RedTeamTargetDetail>;
+
+  /** Delete a red team target. */
+  deleteTarget(uuid: string): Promise<void>;
+
+  /** Probe a target connection. */
+  probeTarget(request: Record<string, unknown>): Promise<Record<string, unknown>>;
+
+  /** Get target profile. */
+  getTargetProfile(uuid: string): Promise<Record<string, unknown>>;
+
+  /** Update target profile. */
+  updateTargetProfile(
+    uuid: string,
+    request: Record<string, unknown>,
+  ): Promise<Record<string, unknown>>;
 
   /** Create a red team scan job. */
   createScan(request: {

--- a/src/cli/commands/redteam.ts
+++ b/src/cli/commands/redteam.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import type { Command } from 'commander';
 import { SdkPromptSetService } from '../../airs/promptsets.js';
 import { SdkRedTeamService } from '../../airs/redteam.js';
@@ -8,19 +9,37 @@ import {
   renderCustomAttackList,
   renderCustomReport,
   renderError,
+  renderPromptDetail,
+  renderPromptList,
+  renderPromptSetDetail,
   renderPromptSetList,
+  renderPropertyNames,
+  renderPropertyValues,
   renderRedteamHeader,
   renderScanList,
   renderScanProgress,
   renderScanStatus,
   renderStaticReport,
+  renderTargetDetail,
   renderTargetList,
+  renderVersionInfo,
 } from '../renderer.js';
 
 /** Create an SdkRedTeamService from config. */
 async function createService() {
   const config = await loadConfig();
   return new SdkRedTeamService({
+    clientId: config.mgmtClientId,
+    clientSecret: config.mgmtClientSecret,
+    tsgId: config.mgmtTsgId,
+    tokenEndpoint: config.mgmtTokenEndpoint,
+  });
+}
+
+/** Create an SdkPromptSetService from config. */
+async function createPromptSetService() {
+  const config = await loadConfig();
+  return new SdkPromptSetService({
     clientId: config.mgmtClientId,
     clientSecret: config.mgmtClientSecret,
     tsgId: config.mgmtTsgId,
@@ -178,17 +197,146 @@ export function registerRedteamCommand(program: Command): void {
     });
 
   // -----------------------------------------------------------------------
-  // redteam targets — list configured targets
+  // redteam targets — target CRUD subcommands
   // -----------------------------------------------------------------------
-  redteam
-    .command('targets')
+  const targets = redteam.command('targets').description('Manage red team targets');
+
+  targets
+    .command('list')
     .description('List configured red team targets')
     .action(async () => {
       try {
         renderRedteamHeader();
         const service = await createService();
-        const targets = await service.listTargets();
-        renderTargetList(targets);
+        const list = await service.listTargets();
+        renderTargetList(list);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  targets
+    .command('get <uuid>')
+    .description('Get target details')
+    .action(async (uuid: string) => {
+      try {
+        renderRedteamHeader();
+        const service = await createService();
+        const target = await service.getTarget(uuid);
+        renderTargetDetail(target);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  targets
+    .command('create')
+    .description('Create a new red team target')
+    .requiredOption('--config <path>', 'JSON file with target configuration')
+    .option('--validate', 'Validate target connection before saving')
+    .action(async (opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const target = await service.createTarget(
+          config,
+          opts.validate ? { validate: true } : undefined,
+        );
+        console.log(`  Target created: ${target.uuid}\n`);
+        renderTargetDetail(target);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  targets
+    .command('update <uuid>')
+    .description('Update a red team target')
+    .requiredOption('--config <path>', 'JSON file with target updates')
+    .option('--validate', 'Validate target connection before saving')
+    .action(async (uuid: string, opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const target = await service.updateTarget(
+          uuid,
+          config,
+          opts.validate ? { validate: true } : undefined,
+        );
+        console.log(`  Target updated: ${target.uuid}\n`);
+        renderTargetDetail(target);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  targets
+    .command('delete <uuid>')
+    .description('Delete a red team target')
+    .action(async (uuid: string) => {
+      try {
+        renderRedteamHeader();
+        const service = await createService();
+        await service.deleteTarget(uuid);
+        console.log(`  Target ${uuid} deleted.\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  targets
+    .command('probe')
+    .description('Test target connection without saving')
+    .requiredOption('--config <path>', 'JSON file with connection params')
+    .action(async (opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const result = await service.probeTarget(config);
+        console.log('  Probe result:');
+        console.log(`    ${JSON.stringify(result, null, 2)}\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  targets
+    .command('profile <uuid>')
+    .description('View target profile')
+    .action(async (uuid: string) => {
+      try {
+        renderRedteamHeader();
+        const service = await createService();
+        const profile = await service.getTargetProfile(uuid);
+        console.log('  Target Profile:');
+        console.log(`    ${JSON.stringify(profile, null, 2)}\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  targets
+    .command('update-profile <uuid>')
+    .description('Update target profile')
+    .requiredOption('--config <path>', 'JSON file with profile updates')
+    .action(async (uuid: string, opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const result = await service.updateTargetProfile(uuid, config);
+        console.log('  Profile updated:');
+        console.log(`    ${JSON.stringify(result, null, 2)}\n`);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);
@@ -214,23 +362,284 @@ export function registerRedteamCommand(program: Command): void {
     });
 
   // -----------------------------------------------------------------------
-  // redteam prompt-sets — list custom prompt sets
+  // redteam prompt-sets — prompt set CRUD subcommands
   // -----------------------------------------------------------------------
-  redteam
-    .command('prompt-sets')
+  const promptSets = redteam.command('prompt-sets').description('Manage custom prompt sets');
+
+  promptSets
+    .command('list')
     .description('List custom prompt sets')
     .action(async () => {
       try {
         renderRedteamHeader();
-        const config = await loadConfig();
-        const service = new SdkPromptSetService({
-          clientId: config.mgmtClientId,
-          clientSecret: config.mgmtClientSecret,
-          tsgId: config.mgmtTsgId,
-          tokenEndpoint: config.mgmtTokenEndpoint,
-        });
+        const service = await createPromptSetService();
         const sets = await service.listPromptSets();
         renderPromptSetList(sets);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  promptSets
+    .command('get <uuid>')
+    .description('Get prompt set details')
+    .action(async (uuid: string) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const ps = await service.getPromptSet(uuid);
+        renderPromptSetDetail(ps);
+        const info = await service.getPromptSetVersionInfo(uuid);
+        renderVersionInfo(info);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  promptSets
+    .command('create')
+    .description('Create a new prompt set')
+    .requiredOption('--name <name>', 'Prompt set name')
+    .option('--description <desc>', 'Prompt set description')
+    .action(async (opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const result = await service.createPromptSet(opts.name, opts.description);
+        console.log(`  Prompt set created: ${result.uuid}\n`);
+        console.log(`    Name: ${result.name}\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  promptSets
+    .command('update <uuid>')
+    .description('Update a prompt set')
+    .option('--name <name>', 'New name')
+    .option('--description <desc>', 'New description')
+    .action(async (uuid: string, opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const request: { name?: string; description?: string } = {};
+        if (opts.name) request.name = opts.name;
+        if (opts.description) request.description = opts.description;
+        const result = await service.updatePromptSet(uuid, request);
+        renderPromptSetDetail(result);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  promptSets
+    .command('archive <uuid>')
+    .description('Archive a prompt set')
+    .option('--unarchive', 'Unarchive instead')
+    .action(async (uuid: string, opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const archive = !opts.unarchive;
+        await service.archivePromptSet(uuid, archive);
+        console.log(`  Prompt set ${uuid} ${archive ? 'archived' : 'unarchived'}.\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  promptSets
+    .command('download <uuid>')
+    .description('Download CSV template for a prompt set')
+    .option('--output <path>', 'Output file path')
+    .action(async (uuid: string, opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const csv = await service.downloadTemplate(uuid);
+        const outPath = opts.output || `${uuid}-template.csv`;
+        fs.writeFileSync(outPath, csv, 'utf-8');
+        console.log(`  Template saved to ${outPath}\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  promptSets
+    .command('upload <uuid> <file>')
+    .description('Upload CSV prompts to a prompt set')
+    .action(async (uuid: string, file: string) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const content = fs.readFileSync(file);
+        const blob = new Blob([content], { type: 'text/csv' });
+        const result = await service.uploadPromptsCsv(uuid, blob);
+        console.log(`  ${result.message}\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // redteam prompts — individual prompt CRUD subcommands
+  // -----------------------------------------------------------------------
+  const prompts = redteam.command('prompts').description('Manage prompts within prompt sets');
+
+  prompts
+    .command('list <setUuid>')
+    .description('List prompts in a prompt set')
+    .option('--limit <n>', 'Max results', '50')
+    .action(async (setUuid: string, opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const list = await service.listPrompts(setUuid, {
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderPromptList(list);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  prompts
+    .command('get <setUuid> <promptUuid>')
+    .description('Get prompt details')
+    .action(async (setUuid: string, promptUuid: string) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const prompt = await service.getPrompt(setUuid, promptUuid);
+        renderPromptDetail(prompt);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  prompts
+    .command('add <setUuid>')
+    .description('Add a prompt to a prompt set')
+    .requiredOption('--prompt <text>', 'Prompt text')
+    .option('--goal <text>', 'Prompt goal')
+    .action(async (setUuid: string, opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const result = await service.addPrompt(setUuid, opts.prompt, opts.goal);
+        console.log(`  Prompt added: ${result.uuid}\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  prompts
+    .command('update <setUuid> <promptUuid>')
+    .description('Update a prompt')
+    .option('--prompt <text>', 'New prompt text')
+    .option('--goal <text>', 'New goal')
+    .action(async (setUuid: string, promptUuid: string, opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const request: { prompt?: string; goal?: string } = {};
+        if (opts.prompt) request.prompt = opts.prompt;
+        if (opts.goal) request.goal = opts.goal;
+        const result = await service.updatePrompt(setUuid, promptUuid, request);
+        renderPromptDetail(result);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  prompts
+    .command('delete <setUuid> <promptUuid>')
+    .description('Delete a prompt')
+    .action(async (setUuid: string, promptUuid: string) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        await service.deletePrompt(setUuid, promptUuid);
+        console.log(`  Prompt ${promptUuid} deleted.\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // redteam properties — property name/value management
+  // -----------------------------------------------------------------------
+  const properties = redteam.command('properties').description('Manage custom attack properties');
+
+  properties
+    .command('list')
+    .description('List property names')
+    .action(async () => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const names = await service.getPropertyNames();
+        renderPropertyNames(names);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  properties
+    .command('create')
+    .description('Create a property name')
+    .requiredOption('--name <name>', 'Property name')
+    .action(async (opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const result = await service.createPropertyName(opts.name);
+        console.log(`  Property created: ${result.name}\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  properties
+    .command('values <name>')
+    .description('List values for a property')
+    .action(async (name: string) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const values = await service.getPropertyValues(name);
+        renderPropertyValues(values);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  properties
+    .command('add-value')
+    .description('Create a property value')
+    .requiredOption('--name <name>', 'Property name')
+    .requiredOption('--value <value>', 'Property value')
+    .action(async (opts) => {
+      try {
+        renderRedteamHeader();
+        const service = await createPromptSetService();
+        const result = await service.createPropertyValue(opts.name, opts.value);
+        console.log(`  Value created: ${result.name}=${result.value}\n`);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -454,6 +454,149 @@ export function renderPromptSetList(
   console.log();
 }
 
+/** Render target detail. */
+export function renderTargetDetail(target: {
+  uuid: string;
+  name: string;
+  status: string;
+  targetType?: string;
+  active: boolean;
+  connectionParams?: Record<string, unknown>;
+  background?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}): void {
+  console.log(chalk.bold('\n  Target Detail:\n'));
+  console.log(`    UUID:   ${chalk.dim(target.uuid)}`);
+  console.log(`    Name:   ${target.name}`);
+  console.log(
+    `    Status: ${statusColor(target.active ? 'COMPLETED' : 'FAILED')(target.active ? 'active' : 'inactive')}`,
+  );
+  if (target.targetType) console.log(`    Type:   ${target.targetType}`);
+  if (target.connectionParams) {
+    console.log(chalk.bold('\n    Connection:'));
+    for (const [k, v] of Object.entries(target.connectionParams)) {
+      console.log(`      ${k}: ${chalk.dim(String(v))}`);
+    }
+  }
+  if (target.background) {
+    console.log(chalk.bold('\n    Background:'));
+    for (const [k, v] of Object.entries(target.background)) {
+      if (v != null) console.log(`      ${k}: ${chalk.dim(String(v))}`);
+    }
+  }
+  if (target.metadata) {
+    console.log(chalk.bold('\n    Metadata:'));
+    for (const [k, v] of Object.entries(target.metadata)) {
+      if (v != null) console.log(`      ${k}: ${chalk.dim(String(v))}`);
+    }
+  }
+  console.log();
+}
+
+/** Render prompt set detail. */
+export function renderPromptSetDetail(ps: {
+  uuid: string;
+  name: string;
+  active: boolean;
+  archive: boolean;
+  description?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}): void {
+  console.log(chalk.bold('\n  Prompt Set Detail:\n'));
+  console.log(`    UUID:        ${chalk.dim(ps.uuid)}`);
+  console.log(`    Name:        ${ps.name}`);
+  console.log(
+    `    Status:      ${statusColor(ps.active ? 'COMPLETED' : 'FAILED')(ps.active ? 'active' : 'inactive')}`,
+  );
+  console.log(`    Archived:    ${ps.archive ? 'yes' : 'no'}`);
+  if (ps.description) console.log(`    Description: ${ps.description}`);
+  if (ps.createdAt) console.log(`    Created:     ${chalk.dim(ps.createdAt)}`);
+  if (ps.updatedAt) console.log(`    Updated:     ${chalk.dim(ps.updatedAt)}`);
+  console.log();
+}
+
+/** Render prompt set version info. */
+export function renderVersionInfo(info: {
+  uuid: string;
+  version: number;
+  stats: { total: number; active: number; inactive: number };
+}): void {
+  console.log(chalk.bold('\n  Version Info:\n'));
+  console.log(`    Version:  ${info.version}`);
+  console.log(`    Total:    ${info.stats.total}`);
+  console.log(`    Active:   ${chalk.green(String(info.stats.active))}`);
+  console.log(`    Inactive: ${chalk.dim(String(info.stats.inactive))}`);
+  console.log();
+}
+
+/** Render a list of prompts. */
+export function renderPromptList(
+  prompts: Array<{
+    uuid: string;
+    prompt: string;
+    goal?: string;
+    active: boolean;
+  }>,
+): void {
+  if (prompts.length === 0) {
+    console.log(chalk.dim('  No prompts found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Prompts:\n'));
+  for (const p of prompts) {
+    const status = p.active ? chalk.green('active') : chalk.dim('inactive');
+    const text = p.prompt.length > 80 ? `${p.prompt.substring(0, 77)}...` : p.prompt;
+    console.log(`  ${chalk.dim(p.uuid)}  ${status}`);
+    console.log(`    ${text}`);
+    if (p.goal) console.log(`    ${chalk.dim(`Goal: ${p.goal}`)}`);
+  }
+  console.log();
+}
+
+/** Render prompt detail. */
+export function renderPromptDetail(p: {
+  uuid: string;
+  prompt: string;
+  goal?: string;
+  active: boolean;
+  promptSetId: string;
+}): void {
+  console.log(chalk.bold('\n  Prompt Detail:\n'));
+  console.log(`    UUID:       ${chalk.dim(p.uuid)}`);
+  console.log(`    Set UUID:   ${chalk.dim(p.promptSetId)}`);
+  console.log(`    Status:     ${p.active ? chalk.green('active') : chalk.dim('inactive')}`);
+  console.log(`    Prompt:     ${p.prompt}`);
+  if (p.goal) console.log(`    Goal:       ${p.goal}`);
+  console.log();
+}
+
+/** Render property names list. */
+export function renderPropertyNames(names: Array<{ name: string }>): void {
+  if (names.length === 0) {
+    console.log(chalk.dim('  No property names found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Property Names:\n'));
+  for (const n of names) {
+    console.log(`    ${chalk.dim('•')} ${n.name}`);
+  }
+  console.log();
+}
+
+/** Render property values. */
+export function renderPropertyValues(values: Array<{ name: string; value: string }>): void {
+  if (values.length === 0) {
+    console.log(chalk.dim('  No property values found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Property Values:\n'));
+  for (const v of values) {
+    console.log(`    ${v.name}: ${chalk.dim(v.value)}`);
+  }
+  console.log();
+}
+
 /** Render polling progress inline. */
 export function renderScanProgress(job: {
   status: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,12 @@ export { AirsScanService } from './airs/scanner.js';
 // Core loop & metrics — the main generate→test→evaluate→improve cycle
 // ---------------------------------------------------------------------------
 export type {
+  PromptDetail,
+  PromptSetDetail,
+  PromptSetService,
+  PromptSetVersionInfo,
+  PropertyName,
+  PropertyValue,
   RedTeamAttack,
   RedTeamCategory,
   RedTeamCustomAttack,
@@ -24,6 +30,10 @@ export type {
   RedTeamService,
   RedTeamStaticReport,
   RedTeamTarget,
+  RedTeamTargetCreateRequest,
+  RedTeamTargetDetail,
+  RedTeamTargetUpdateRequest,
+  TargetOperationOptions,
 } from './airs/types.js';
 // ---------------------------------------------------------------------------
 // Audit — profile-level multi-topic evaluation and conflict detection

--- a/tests/unit/airs/promptsets.spec.ts
+++ b/tests/unit/airs/promptsets.spec.ts
@@ -4,6 +4,20 @@ import { SdkPromptSetService } from '../../../src/airs/promptsets.js';
 const mockCreatePromptSet = vi.fn();
 const mockCreatePrompt = vi.fn();
 const mockListPromptSets = vi.fn();
+const mockGetPromptSet = vi.fn();
+const mockUpdatePromptSet = vi.fn();
+const mockArchivePromptSet = vi.fn();
+const mockGetPromptSetVersionInfo = vi.fn();
+const mockDownloadTemplate = vi.fn();
+const mockUploadPromptsCsv = vi.fn();
+const mockListPrompts = vi.fn();
+const mockGetPrompt = vi.fn();
+const mockUpdatePrompt = vi.fn();
+const mockDeletePrompt = vi.fn();
+const mockGetPropertyNames = vi.fn();
+const mockCreatePropertyName = vi.fn();
+const mockGetPropertyValues = vi.fn();
+const mockCreatePropertyValue = vi.fn();
 
 vi.mock('@cdot65/prisma-airs-sdk', () => ({
   RedTeamClient: vi.fn().mockImplementation(() => ({
@@ -11,6 +25,20 @@ vi.mock('@cdot65/prisma-airs-sdk', () => ({
       createPromptSet: mockCreatePromptSet,
       createPrompt: mockCreatePrompt,
       listPromptSets: mockListPromptSets,
+      getPromptSet: mockGetPromptSet,
+      updatePromptSet: mockUpdatePromptSet,
+      archivePromptSet: mockArchivePromptSet,
+      getPromptSetVersionInfo: mockGetPromptSetVersionInfo,
+      downloadTemplate: mockDownloadTemplate,
+      uploadPromptsCsv: mockUploadPromptsCsv,
+      listPrompts: mockListPrompts,
+      getPrompt: mockGetPrompt,
+      updatePrompt: mockUpdatePrompt,
+      deletePrompt: mockDeletePrompt,
+      getPropertyNames: mockGetPropertyNames,
+      createPropertyName: mockCreatePropertyName,
+      getPropertyValues: mockGetPropertyValues,
+      createPropertyValue: mockCreatePropertyValue,
     },
   })),
 }));
@@ -131,6 +159,254 @@ describe('SdkPromptSetService', () => {
 
       const result = await service.listPromptSets();
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('getPromptSet', () => {
+    it('returns normalized prompt set detail', async () => {
+      mockGetPromptSet.mockResolvedValue({
+        uuid: 'ps-1',
+        name: 'My Set',
+        active: true,
+        archive: false,
+        description: 'Test desc',
+        created_at: '2026-03-08T00:00:00Z',
+        updated_at: '2026-03-08T01:00:00Z',
+      });
+
+      const result = await service.getPromptSet('ps-1');
+      expect(result).toEqual({
+        uuid: 'ps-1',
+        name: 'My Set',
+        active: true,
+        archive: false,
+        description: 'Test desc',
+        createdAt: '2026-03-08T00:00:00Z',
+        updatedAt: '2026-03-08T01:00:00Z',
+      });
+      expect(mockGetPromptSet).toHaveBeenCalledWith('ps-1');
+    });
+
+    it('handles missing optional fields', async () => {
+      mockGetPromptSet.mockResolvedValue({
+        uuid: 'ps-2',
+        name: 'Minimal',
+        active: true,
+        archive: false,
+      });
+
+      const result = await service.getPromptSet('ps-2');
+      expect(result.description).toBeUndefined();
+      expect(result.createdAt).toBeUndefined();
+    });
+  });
+
+  describe('updatePromptSet', () => {
+    it('updates and returns normalized detail', async () => {
+      mockUpdatePromptSet.mockResolvedValue({
+        uuid: 'ps-1',
+        name: 'Updated Set',
+        active: true,
+        archive: false,
+        description: 'New desc',
+        created_at: '2026-03-08T00:00:00Z',
+        updated_at: '2026-03-08T02:00:00Z',
+      });
+
+      const result = await service.updatePromptSet('ps-1', {
+        name: 'Updated Set',
+        description: 'New desc',
+      });
+      expect(result.name).toBe('Updated Set');
+      expect(result.description).toBe('New desc');
+      expect(mockUpdatePromptSet).toHaveBeenCalledWith('ps-1', {
+        name: 'Updated Set',
+        description: 'New desc',
+      });
+    });
+  });
+
+  describe('archivePromptSet', () => {
+    it('archives a prompt set', async () => {
+      mockArchivePromptSet.mockResolvedValue(undefined);
+      await expect(service.archivePromptSet('ps-1', true)).resolves.not.toThrow();
+      expect(mockArchivePromptSet).toHaveBeenCalledWith('ps-1', { archive: true });
+    });
+
+    it('unarchives a prompt set', async () => {
+      mockArchivePromptSet.mockResolvedValue(undefined);
+      await service.archivePromptSet('ps-1', false);
+      expect(mockArchivePromptSet).toHaveBeenCalledWith('ps-1', { archive: false });
+    });
+  });
+
+  describe('getPromptSetVersionInfo', () => {
+    it('returns version info with stats', async () => {
+      mockGetPromptSetVersionInfo.mockResolvedValue({
+        uuid: 'ps-1',
+        version: 3,
+        stats: { total: 50, active: 45, inactive: 5 },
+      });
+
+      const result = await service.getPromptSetVersionInfo('ps-1');
+      expect(result).toEqual({
+        uuid: 'ps-1',
+        version: 3,
+        stats: { total: 50, active: 45, inactive: 5 },
+      });
+      expect(mockGetPromptSetVersionInfo).toHaveBeenCalledWith('ps-1');
+    });
+  });
+
+  describe('downloadTemplate', () => {
+    it('returns CSV template string', async () => {
+      mockDownloadTemplate.mockResolvedValue('prompt,goal\n"test","test goal"');
+      const result = await service.downloadTemplate('ps-1');
+      expect(result).toBe('prompt,goal\n"test","test goal"');
+      expect(mockDownloadTemplate).toHaveBeenCalledWith('ps-1');
+    });
+  });
+
+  describe('uploadPromptsCsv', () => {
+    it('uploads CSV and returns response', async () => {
+      mockUploadPromptsCsv.mockResolvedValue({ message: 'Uploaded 10 prompts', status: 200 });
+      const blob = new Blob(['prompt,goal\n"test","goal"'], { type: 'text/csv' });
+      const result = await service.uploadPromptsCsv('ps-1', blob);
+      expect(result).toEqual({ message: 'Uploaded 10 prompts', status: 200 });
+      expect(mockUploadPromptsCsv).toHaveBeenCalledWith('ps-1', blob);
+    });
+  });
+
+  describe('listPrompts', () => {
+    it('returns normalized prompt list', async () => {
+      mockListPrompts.mockResolvedValue({
+        data: [
+          {
+            uuid: 'p-1',
+            prompt: 'test prompt',
+            goal: 'test goal',
+            active: true,
+            prompt_set_id: 'ps-1',
+          },
+          { uuid: 'p-2', prompt: 'another', active: false, prompt_set_id: 'ps-1' },
+        ],
+      });
+
+      const result = await service.listPrompts('ps-1', { limit: 10 });
+      expect(result).toEqual([
+        {
+          uuid: 'p-1',
+          prompt: 'test prompt',
+          goal: 'test goal',
+          active: true,
+          promptSetId: 'ps-1',
+        },
+        { uuid: 'p-2', prompt: 'another', goal: undefined, active: false, promptSetId: 'ps-1' },
+      ]);
+      expect(mockListPrompts).toHaveBeenCalledWith('ps-1', { limit: 10 });
+    });
+
+    it('returns empty array when no data', async () => {
+      mockListPrompts.mockResolvedValue({ data: [] });
+      const result = await service.listPrompts('ps-1');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getPrompt', () => {
+    it('returns normalized prompt detail', async () => {
+      mockGetPrompt.mockResolvedValue({
+        uuid: 'p-1',
+        prompt: 'test',
+        goal: 'should block',
+        active: true,
+        prompt_set_id: 'ps-1',
+      });
+
+      const result = await service.getPrompt('ps-1', 'p-1');
+      expect(result).toEqual({
+        uuid: 'p-1',
+        prompt: 'test',
+        goal: 'should block',
+        active: true,
+        promptSetId: 'ps-1',
+      });
+      expect(mockGetPrompt).toHaveBeenCalledWith('ps-1', 'p-1');
+    });
+  });
+
+  describe('updatePrompt', () => {
+    it('updates and returns normalized prompt', async () => {
+      mockUpdatePrompt.mockResolvedValue({
+        uuid: 'p-1',
+        prompt: 'updated prompt',
+        goal: 'new goal',
+        active: true,
+        prompt_set_id: 'ps-1',
+      });
+
+      const result = await service.updatePrompt('ps-1', 'p-1', {
+        prompt: 'updated prompt',
+        goal: 'new goal',
+      });
+      expect(result.prompt).toBe('updated prompt');
+      expect(result.goal).toBe('new goal');
+      expect(mockUpdatePrompt).toHaveBeenCalledWith('ps-1', 'p-1', {
+        prompt: 'updated prompt',
+        goal: 'new goal',
+      });
+    });
+  });
+
+  describe('deletePrompt', () => {
+    it('deletes a prompt', async () => {
+      mockDeletePrompt.mockResolvedValue(undefined);
+      await expect(service.deletePrompt('ps-1', 'p-1')).resolves.not.toThrow();
+      expect(mockDeletePrompt).toHaveBeenCalledWith('ps-1', 'p-1');
+    });
+  });
+
+  describe('getPropertyNames', () => {
+    it('returns property names', async () => {
+      mockGetPropertyNames.mockResolvedValue([{ name: 'category' }, { name: 'severity' }]);
+      const result = await service.getPropertyNames();
+      expect(result).toEqual([{ name: 'category' }, { name: 'severity' }]);
+    });
+  });
+
+  describe('createPropertyName', () => {
+    it('creates and returns property name', async () => {
+      mockCreatePropertyName.mockResolvedValue({ name: 'priority' });
+      const result = await service.createPropertyName('priority');
+      expect(result).toEqual({ name: 'priority' });
+      expect(mockCreatePropertyName).toHaveBeenCalledWith({ name: 'priority' });
+    });
+  });
+
+  describe('getPropertyValues', () => {
+    it('returns property values', async () => {
+      mockGetPropertyValues.mockResolvedValue([
+        { name: 'category', value: 'security' },
+        { name: 'category', value: 'safety' },
+      ]);
+      const result = await service.getPropertyValues('category');
+      expect(result).toEqual([
+        { name: 'category', value: 'security' },
+        { name: 'category', value: 'safety' },
+      ]);
+      expect(mockGetPropertyValues).toHaveBeenCalledWith('category');
+    });
+  });
+
+  describe('createPropertyValue', () => {
+    it('creates and returns property value', async () => {
+      mockCreatePropertyValue.mockResolvedValue({ name: 'category', value: 'compliance' });
+      const result = await service.createPropertyValue('category', 'compliance');
+      expect(result).toEqual({ name: 'category', value: 'compliance' });
+      expect(mockCreatePropertyValue).toHaveBeenCalledWith({
+        name: 'category',
+        value: 'compliance',
+      });
     });
   });
 });

--- a/tests/unit/airs/redteam.spec.ts
+++ b/tests/unit/airs/redteam.spec.ts
@@ -2,6 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SdkRedTeamService } from '../../../src/airs/redteam.js';
 
 const mockTargetsList = vi.fn();
+const mockTargetsGet = vi.fn();
+const mockTargetsCreate = vi.fn();
+const mockTargetsUpdate = vi.fn();
+const mockTargetsDelete = vi.fn();
+const mockTargetsProbe = vi.fn();
+const mockTargetsGetProfile = vi.fn();
+const mockTargetsUpdateProfile = vi.fn();
 const mockScansCreate = vi.fn();
 const mockScansGet = vi.fn();
 const mockScansList = vi.fn();
@@ -14,7 +21,16 @@ const mockCustomAttackReportsListCustomAttacks = vi.fn();
 
 function makeMockClient() {
   return {
-    targets: { list: mockTargetsList },
+    targets: {
+      list: mockTargetsList,
+      get: mockTargetsGet,
+      create: mockTargetsCreate,
+      update: mockTargetsUpdate,
+      delete: mockTargetsDelete,
+      probe: mockTargetsProbe,
+      getProfile: mockTargetsGetProfile,
+      updateProfile: mockTargetsUpdateProfile,
+    },
     scans: {
       create: mockScansCreate,
       get: mockScansGet,
@@ -516,6 +532,181 @@ describe('SdkRedTeamService', () => {
 
       const result = await service.getCategories();
       expect(result[0].subCategories).toEqual([]);
+    });
+  });
+
+  describe('getTarget', () => {
+    it('returns normalized target detail', async () => {
+      mockTargetsGet.mockResolvedValue({
+        uuid: 't-1',
+        name: 'My Target',
+        status: 'active',
+        target_type: 'REST',
+        active: true,
+        connection_params: { api_endpoint: 'https://example.com' },
+        background: { industry: 'finance', use_case: 'chatbot', competitors: ['acme'] },
+        additional_context: {
+          system_prompt: 'You are helpful',
+          use_case_description: 'desc',
+          documents: [],
+        },
+        metadata: { multi_turn: false, rate_limit: 10, is_streaming_enabled: false },
+      });
+
+      const result = await service.getTarget('t-1');
+      expect(result.uuid).toBe('t-1');
+      expect(result.name).toBe('My Target');
+      expect(result.targetType).toBe('REST');
+      expect(result.connectionParams).toEqual({ api_endpoint: 'https://example.com' });
+      expect(result.background).toEqual({
+        industry: 'finance',
+        use_case: 'chatbot',
+        competitors: ['acme'],
+      });
+      expect(result.additionalContext).toEqual({
+        system_prompt: 'You are helpful',
+        use_case_description: 'desc',
+        documents: [],
+      });
+      expect(result.metadata).toEqual({
+        multi_turn: false,
+        rate_limit: 10,
+        is_streaming_enabled: false,
+      });
+      expect(mockTargetsGet).toHaveBeenCalledWith('t-1');
+    });
+
+    it('handles missing optional fields', async () => {
+      mockTargetsGet.mockResolvedValue({
+        uuid: 't-2',
+        name: 'Minimal',
+        status: 'inactive',
+        active: false,
+      });
+
+      const result = await service.getTarget('t-2');
+      expect(result.uuid).toBe('t-2');
+      expect(result.connectionParams).toBeUndefined();
+      expect(result.background).toBeUndefined();
+      expect(result.metadata).toBeUndefined();
+    });
+  });
+
+  describe('createTarget', () => {
+    it('creates target and returns normalized detail', async () => {
+      mockTargetsCreate.mockResolvedValue({
+        uuid: 't-new',
+        name: 'New Target',
+        status: 'active',
+        target_type: 'REST',
+        active: true,
+        connection_params: { api_endpoint: 'https://api.example.com' },
+      });
+
+      const result = await service.createTarget({
+        name: 'New Target',
+        target_type: 'REST',
+        connection_params: { api_endpoint: 'https://api.example.com' },
+      });
+
+      expect(result.uuid).toBe('t-new');
+      expect(result.name).toBe('New Target');
+      expect(mockTargetsCreate).toHaveBeenCalledWith(
+        {
+          name: 'New Target',
+          target_type: 'REST',
+          connection_params: { api_endpoint: 'https://api.example.com' },
+        },
+        undefined,
+      );
+    });
+
+    it('passes validate option', async () => {
+      mockTargetsCreate.mockResolvedValue({
+        uuid: 't-new',
+        name: 'Validated Target',
+        status: 'active',
+        target_type: 'REST',
+        active: true,
+      });
+
+      await service.createTarget(
+        { name: 'Validated Target', target_type: 'REST', connection_params: {} },
+        { validate: true },
+      );
+
+      expect(mockTargetsCreate).toHaveBeenCalledWith(
+        { name: 'Validated Target', target_type: 'REST', connection_params: {} },
+        { validate: true },
+      );
+    });
+  });
+
+  describe('updateTarget', () => {
+    it('updates target and returns normalized detail', async () => {
+      mockTargetsUpdate.mockResolvedValue({
+        uuid: 't-1',
+        name: 'Updated Target',
+        status: 'active',
+        target_type: 'REST',
+        active: true,
+      });
+
+      const result = await service.updateTarget('t-1', { name: 'Updated Target' });
+      expect(result.uuid).toBe('t-1');
+      expect(result.name).toBe('Updated Target');
+      expect(mockTargetsUpdate).toHaveBeenCalledWith('t-1', { name: 'Updated Target' }, undefined);
+    });
+
+    it('passes validate option', async () => {
+      mockTargetsUpdate.mockResolvedValue({
+        uuid: 't-1',
+        name: 'Target',
+        status: 'active',
+        target_type: 'REST',
+        active: true,
+      });
+
+      await service.updateTarget('t-1', { name: 'Target' }, { validate: true });
+      expect(mockTargetsUpdate).toHaveBeenCalledWith('t-1', { name: 'Target' }, { validate: true });
+    });
+  });
+
+  describe('deleteTarget', () => {
+    it('deletes target', async () => {
+      mockTargetsDelete.mockResolvedValue(undefined);
+      await expect(service.deleteTarget('t-1')).resolves.not.toThrow();
+      expect(mockTargetsDelete).toHaveBeenCalledWith('t-1');
+    });
+  });
+
+  describe('probeTarget', () => {
+    it('probes target connection', async () => {
+      mockTargetsProbe.mockResolvedValue({ status: 'connected', latency_ms: 42 });
+      const result = await service.probeTarget({ api_endpoint: 'https://example.com' });
+      expect(result).toEqual({ status: 'connected', latency_ms: 42 });
+      expect(mockTargetsProbe).toHaveBeenCalledWith({ api_endpoint: 'https://example.com' });
+    });
+  });
+
+  describe('getTargetProfile', () => {
+    it('returns target profile', async () => {
+      mockTargetsGetProfile.mockResolvedValue({
+        profiling_status: 'COMPLETED',
+        categories: ['safety'],
+      });
+      const result = await service.getTargetProfile('t-1');
+      expect(result).toEqual({ profiling_status: 'COMPLETED', categories: ['safety'] });
+      expect(mockTargetsGetProfile).toHaveBeenCalledWith('t-1');
+    });
+  });
+
+  describe('updateTargetProfile', () => {
+    it('updates target profile', async () => {
+      mockTargetsUpdateProfile.mockResolvedValue({ profiling_status: 'PENDING' });
+      const result = await service.updateTargetProfile('t-1', { categories: ['security'] });
+      expect(result).toEqual({ profiling_status: 'PENDING' });
+      expect(mockTargetsUpdateProfile).toHaveBeenCalledWith('t-1', { categories: ['security'] });
     });
   });
 


### PR DESCRIPTION
## Summary

- Upgrade `@cdot65/prisma-airs-sdk` from v0.4.0 to v0.6.0
- Full **target CRUD** — create/get/update/delete with `--validate` connection validation, probe, profile management
- Full **prompt set CRUD** — get/update/archive/version-info/CSV upload/download template
- Full **individual prompt CRUD** — list/get/add/update/delete within prompt sets
- **Property name/value management** — list/create property names and values
- New CLI subcommand groups: `targets`, `prompt-sets`, `prompts`, `properties`
- Version bump to 1.7.0

## Test plan

- [x] 360 tests pass (27 new, all green)
- [x] 100% coverage on `redteam.ts` and `promptsets.ts`
- [x] 99.48% overall statement coverage
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm run lint` clean
- [x] `pnpm run build` clean
- [ ] CI workflow passes
- [ ] E2E: `daystrom redteam targets list` works against real API
- [ ] E2E: `daystrom redteam prompt-sets list` works against real API

Closes #42, #43, #44, #45, #46, #47, #48, #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)