### PR TITLE
docs: sync all mkdocs pages with v1.7.0

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,37 @@
 # Release Notes
 
+## v1.7.0
+
+### Features
+
+- **Red team target CRUD**: Full target lifecycle management — `create`, `get`, `update`, `delete` via CLI (`daystrom redteam targets <subcommand>`) and library API (`SdkRedTeamService`).
+- **Target connection validation**: `--validate` flag on `targets create` and `targets update` validates connectivity before saving (SDK v0.6.0 `TargetOperationOptions`).
+- **Target probe**: `daystrom redteam targets probe --config conn.json` tests a target connection without persisting.
+- **Target profile management**: `targets profile <uuid>` and `targets update-profile <uuid>` for target profiling configuration.
+- **Prompt set full CRUD**: `get`, `update`, `archive`/unarchive, `version-info`, CSV template download via `daystrom redteam prompt-sets <subcommand>`.
+- **CSV prompt upload**: `daystrom redteam prompt-sets upload <uuid> file.csv` for bulk prompt ingestion (SDK v0.6.0 `uploadPromptsCsv()`).
+- **Individual prompt CRUD**: `list`, `get`, `add`, `update`, `delete` prompts within sets via `daystrom redteam prompts <subcommand>`.
+- **Property management**: `daystrom redteam properties {list,create,values,add-value}` for custom attack property names and values.
+- **SDK upgrade**: `@cdot65/prisma-airs-sdk` v0.4.0 → v0.6.0 — fully typed target schemas (connection params, background, metadata, additional context), no breaking changes.
+
+### CLI Changes
+
+Existing flat commands refactored to subcommand groups:
+
+| Before (v1.6.0) | After (v1.7.0) |
+|-----------------|----------------|
+| `daystrom redteam targets` | `daystrom redteam targets list` |
+| `daystrom redteam prompt-sets` | `daystrom redteam prompt-sets list` |
+| — | `daystrom redteam targets {get,create,update,delete,probe,profile,update-profile}` |
+| — | `daystrom redteam prompt-sets {get,create,update,archive,download,upload}` |
+| — | `daystrom redteam prompts {list,get,add,update,delete}` |
+| — | `daystrom redteam properties {list,create,values,add-value}` |
+
+### Tests
+
+- 360 tests across 24 spec files (up from 333)
+- 100% coverage on `redteam.ts` and `promptsets.ts`
+
 ## v1.6.0
 
 ### Features

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -10,9 +10,11 @@ src/
 ├── config/           Zod-validated config schema + cascade loader
 ├── core/             Async generator loop, efficacy metrics, AIRS constraints
 ├── llm/              LangChain provider factory, structured output, prompts
-├── airs/             Scanner (batch scan) and Management (topic CRUD + profiles)
+├── airs/             Scanner, Management (topic CRUD), Red Team (scan CRUD), Prompt Sets
 ├── memory/           Learning store, extractor, budget-aware injector
 ├── persistence/      JSON file store for run state
+├── audit/            Profile-level multi-topic evaluation + conflict detection
+├── report/           Structured evaluation reports (JSON/HTML)
 └── index.ts          Library re-exports
 ```
 
@@ -46,13 +48,15 @@ graph TD
 
 | Module | What it does |
 |--------|-------------|
-| **`cli/`** | Commander CLI with 4 commands (`generate`, `resume`, `report`, `list`), Inquirer prompts, and Chalk terminal output |
+| **`cli/`** | Commander CLI with 6 command groups (`generate`, `resume`, `report`, `list`, `audit`, `redteam`), Inquirer prompts, and Chalk terminal output |
 | **`config/`** | Zod schema with coercion and defaults; cascade loader merges CLI flags, env vars, config file, and defaults |
 | **`core/`** | AsyncGenerator loop that yields typed events, metric computation (TPR/TNR/F1), and AIRS constraint validation |
 | **`llm/`** | Factory for 6 LangChain providers, structured output with Zod schemas, and prompt templates for all 4 LLM calls |
-| **`airs/`** | Scan API with batched concurrency via `p-limit`, Management API for topic CRUD and profile linking via OAuth2 |
+| **`airs/`** | Scan API with batched concurrency via `p-limit`, Management API for topic CRUD and profile linking, Red Team service for scan CRUD/polling/reports, Prompt Set service for custom prompt set management |
 | **`memory/`** | File-based learning store, LLM-driven extraction after each run, and budget-aware injection into future prompts |
 | **`persistence/`** | `JsonFileStore` serializes `RunState` to `~/.daystrom/runs/` for pause/resume support |
+| **`audit/`** | Profile-level multi-topic evaluation — generates tests per topic, computes per-topic and composite metrics, detects cross-topic conflicts |
+| **`report/`** | Structured evaluation report generation — JSON and self-contained HTML output with iteration trends, metrics, and test details |
 
 ## Tech Stack
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -16,13 +16,15 @@ Tests live in `tests/`, mirroring the `src/` layout:
 
 ```
 tests/
-├── unit/                  16 spec files
-│   ├── airs/              scanner.spec.ts, management.spec.ts
+├── unit/                  22 spec files
+│   ├── airs/              scanner.spec.ts, management.spec.ts, redteam.spec.ts, promptsets.spec.ts
+│   ├── audit/             evaluator.spec.ts, runner.spec.ts, report.spec.ts
 │   ├── config/            schema.spec.ts, loader.spec.ts
 │   ├── core/              loop.spec.ts, metrics.spec.ts, constraints.spec.ts
 │   ├── llm/               provider.spec.ts, schemas.spec.ts, service.spec.ts, prompts.spec.ts
 │   ├── memory/            store.spec.ts, extractor.spec.ts, injector.spec.ts, diff.spec.ts
-│   └── persistence/       store.spec.ts
+│   ├── persistence/       store.spec.ts
+│   └── report/            json.spec.ts, html.spec.ts
 ├── integration/           loop.integration.spec.ts
 ├── e2e/                   vertex-provider.e2e.spec.ts (opt-in)
 └── helpers/               mocks.ts

--- a/docs/examples/guardrail-to-redteam.md
+++ b/docs/examples/guardrail-to-redteam.md
@@ -77,10 +77,10 @@ When the loop completes, Daystrom:
 
 ## Step 2: Find Your Prompt Set UUID
 
-Use `daystrom redteam prompt-sets` to list all custom prompt sets and find the UUID for the one you just created:
+Use `daystrom redteam prompt-sets list` to list all custom prompt sets and find the UUID for the one you just created:
 
 ```bash
-daystrom redteam prompt-sets
+daystrom redteam prompt-sets list
 ```
 
 ```
@@ -103,7 +103,7 @@ Copy the UUID for `pokemon-guardrail-tests` — you'll pass it to the scan comma
 List available targets to get the UUID for your AI application:
 
 ```bash
-daystrom redteam targets
+daystrom redteam targets list
 ```
 
 ```
@@ -284,13 +284,13 @@ daystrom generate \
   --prompt-set-name "$PROMPT_SET_NAME"
 
 # 2. Find the prompt set UUID
-daystrom redteam prompt-sets
+daystrom redteam prompt-sets list
 # Copy the UUID for your prompt set from the output
 
 PROMPT_SET_UUID="<uuid-from-prompt-sets-output>"
 
 # 3. Find target UUID
-daystrom redteam targets
+daystrom redteam targets list
 
 # 4. Launch red team scan (async)
 daystrom redteam scan \
@@ -309,4 +309,4 @@ daystrom redteam report "$JOB_ID" --attacks
 ```
 
 !!! note "Replace placeholder values"
-    Replace `PROMPT_SET_UUID` and `JOB_ID` with the actual values from your run. Target UUIDs can be found with `daystrom redteam targets`.
+    Replace `PROMPT_SET_UUID` and `JOB_ID` with the actual values from your run. Target UUIDs can be found with `daystrom redteam targets list`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,20 @@ Daystrom is a CLI tool that takes a plain-English description of what you want t
 
     Optionally carry forward test prompts across iterations with dedup, catching regressions that fresh tests might miss.
 
+-   :material-sword:{ .lg .middle } **AI Red Teaming**
+
+    ---
+
+    Launch static, dynamic, and custom adversarial scans against AI targets. Full CRUD on targets, prompt sets, and prompts via `daystrom redteam`.
+
+    [:octicons-arrow-right-24: Red Team](features/red-team.md)
+
+-   :material-clipboard-check:{ .lg .middle } **Profile Audits**
+
+    ---
+
+    Evaluate all topics in a security profile at once. Per-topic metrics, composite scores, and cross-topic conflict detection via `daystrom audit`.
+
 </div>
 
 ---

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -43,6 +43,18 @@ All environment variables Daystrom recognizes, grouped by category. Copy `.env.e
 
 ---
 
+## AIRS Red Team API
+
+Red team operations reuse the same OAuth2 credentials as the Management API above. These optional overrides let you point at dedicated red team endpoints:
+
+| Variable | Required | What it does |
+|----------|:--------:|-------------|
+| `PANW_RED_TEAM_DATA_ENDPOINT` | -- | Custom red team data endpoint |
+| `PANW_RED_TEAM_MGMT_ENDPOINT` | -- | Custom red team management endpoint |
+| `PANW_RED_TEAM_TOKEN_ENDPOINT` | -- | Custom red team token endpoint |
+
+---
+
 ## Tuning
 
 | Variable | Default | Range | What it controls |


### PR DESCRIPTION
## Summary
- Fix broken examples in guardrail-to-redteam workflow (`targets` → `targets list`, `prompt-sets` → `prompt-sets list`)
- Update architecture overview: 6 command groups, airs/ red team + prompt set services, add audit/ and report/ modules
- Update testing docs: 22 spec files with redteam, promptsets, audit, report specs
- Add `PANW_RED_TEAM_*` env vars to environment-variables reference
- Add Red Team and Profile Audit feature cards to index page

## Test plan
- [x] `pnpm run format:check` — no violations
- [x] `pnpm tsc --noEmit` — passes
- [x] `mkdocs build --strict` — builds successfully
- [x] Grep confirms no stale `daystrom redteam targets`/`prompt-sets` (without subcommand) in docs outside release notes Before/After table

🤖 Generated with [Claude Code](https://claude.com/claude-code)