### PR TITLE
feat: model security foundation — SDK v0.6.1 + types + service

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.14.4",
-    "@cdot65/prisma-airs-sdk": "^0.6.0",
+    "@cdot65/prisma-airs-sdk": "^0.6.1",
     "@inquirer/prompts": "^8.3.0",
     "@langchain/anthropic": "^1.3.21",
     "@langchain/aws": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.14.4
         version: 0.14.4(zod@3.25.76)
       '@cdot65/prisma-airs-sdk':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.6.1
+        version: 0.6.1
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.0(@types/node@22.19.13)
@@ -314,8 +314,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cdot65/prisma-airs-sdk@0.6.0':
-    resolution: {integrity: sha512-QsaeEK4SMsUZAKutX/LB0bqxN6Buf6JA2QYFh3CCG3GicKMtGerNdKSSBk601yIaU9iMQlTJkt6MpH+4yBAfjA==}
+  '@cdot65/prisma-airs-sdk@0.6.1':
+    resolution: {integrity: sha512-2vBWkSrJHruO2I++pGSp30OEjZihuoKC46RAosEBo6ru7EW9amAAtBWuO0fzI0NMrZwbrR+XEvh6znQ/zkxEMA==}
     engines: {node: '>=18'}
 
   '@cfworker/json-schema@4.1.1':
@@ -2434,7 +2434,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.5':
     optional: true
 
-  '@cdot65/prisma-airs-sdk@0.6.0':
+  '@cdot65/prisma-airs-sdk@0.6.1':
     dependencies:
       zod: 3.25.76
 

--- a/src/airs/modelsecurity.ts
+++ b/src/airs/modelsecurity.ts
@@ -1,0 +1,439 @@
+import { ModelSecurityClient, type ModelSecurityClientOptions } from '@cdot65/prisma-airs-sdk';
+import type {
+  ModelSecurityEvaluation,
+  ModelSecurityFile,
+  ModelSecurityFileListOptions,
+  ModelSecurityGroup,
+  ModelSecurityGroupCreateRequest,
+  ModelSecurityGroupListOptions,
+  ModelSecurityGroupUpdateRequest,
+  ModelSecurityLabel,
+  ModelSecurityPyPIAuth,
+  ModelSecurityRule,
+  ModelSecurityRuleEditableField,
+  ModelSecurityRuleInstance,
+  ModelSecurityRuleInstanceListOptions,
+  ModelSecurityRuleInstanceUpdateRequest,
+  ModelSecurityRuleListOptions,
+  ModelSecurityScan,
+  ModelSecurityScanListOptions,
+  ModelSecurityService,
+  ModelSecurityViolation,
+} from './types.js';
+
+/** Normalize an SDK security group response. */
+function normalizeGroup(raw: Record<string, unknown>): ModelSecurityGroup {
+  return {
+    uuid: raw.uuid as string,
+    name: raw.name as string,
+    description: raw.description as string,
+    sourceType: raw.source_type as string,
+    state: raw.state as string,
+    createdAt: raw.created_at as string,
+    updatedAt: raw.updated_at as string,
+  };
+}
+
+/** Normalize an SDK rule instance response. */
+function normalizeRuleInstance(raw: Record<string, unknown>): ModelSecurityRuleInstance {
+  return {
+    uuid: raw.uuid as string,
+    securityGroupUuid: raw.security_group_uuid as string,
+    securityRuleUuid: raw.security_rule_uuid as string,
+    state: raw.state as string,
+    createdAt: raw.created_at as string,
+    updatedAt: raw.updated_at as string,
+    rule: raw.rule as Record<string, unknown>,
+    fieldValues: (raw.field_values ?? {}) as Record<string, unknown>,
+  };
+}
+
+/** Normalize an SDK security rule response. */
+function normalizeRule(raw: Record<string, unknown>): ModelSecurityRule {
+  const editableFields = (raw.editable_fields ?? []) as Array<Record<string, unknown>>;
+  return {
+    uuid: raw.uuid as string,
+    name: raw.name as string,
+    description: raw.description as string,
+    ruleType: raw.rule_type as string,
+    compatibleSources: raw.compatible_sources as string[],
+    defaultState: raw.default_state as string,
+    remediation: raw.remediation as ModelSecurityRule['remediation'],
+    editableFields: editableFields.map(
+      (f) =>
+        ({
+          attributeName: f.attribute_name as string,
+          type: f.type as string,
+          displayName: f.display_name as string,
+          displayType: f.display_type as string,
+          description: f.description as string | undefined,
+          dropdownValues: f.dropdown_values as Array<{ value: string; label: string }> | undefined,
+        }) as ModelSecurityRuleEditableField,
+    ),
+    constantValues: (raw.constant_values ?? {}) as Record<string, unknown>,
+    defaultValues: (raw.default_values ?? {}) as Record<string, unknown>,
+  };
+}
+
+/** Normalize an SDK scan response. */
+function normalizeScan(raw: Record<string, unknown>): ModelSecurityScan {
+  const summary = raw.eval_summary as Record<string, unknown> | null;
+  return {
+    uuid: raw.uuid as string,
+    status: raw.status as string,
+    evalSummary: summary
+      ? {
+          rulesFailed: (summary.rules_failed ?? 0) as number,
+          rulesPassed: (summary.rules_passed ?? 0) as number,
+          totalRules: (summary.total_rules ?? 0) as number,
+        }
+      : null,
+    createdAt: raw.created_at as string,
+    updatedAt: raw.updated_at as string,
+    labels: (raw.labels ?? []) as Array<{ key: string; value: string }>,
+  };
+}
+
+/** Normalize an SDK evaluation response. */
+function normalizeEvaluation(raw: Record<string, unknown>): ModelSecurityEvaluation {
+  return {
+    uuid: raw.uuid as string,
+    evalOutcome: raw.eval_outcome as string,
+    result: raw.result as string,
+    securityRuleUuid: raw.security_rule_uuid as string,
+    ruleName: raw.rule_name as string,
+  };
+}
+
+/** Normalize an SDK violation response. */
+function normalizeViolation(raw: Record<string, unknown>): ModelSecurityViolation {
+  return {
+    uuid: raw.uuid as string,
+    ruleName: raw.rule_name as string,
+    filePath: raw.file_path as string,
+    description: raw.description as string,
+  };
+}
+
+/** Normalize an SDK file response. */
+function normalizeFile(raw: Record<string, unknown>): ModelSecurityFile {
+  return {
+    filePath: raw.file_path as string,
+    type: raw.type as string,
+    result: raw.result as string,
+  };
+}
+
+/**
+ * Wraps the SDK's ModelSecurityClient to implement ModelSecurityService.
+ * Provides security group CRUD, rule browsing, scan operations, and label management.
+ */
+export class SdkModelSecurityService implements ModelSecurityService {
+  private client: ModelSecurityClient;
+
+  constructor(opts?: ModelSecurityClientOptions) {
+    this.client = new ModelSecurityClient(opts);
+  }
+
+  // -----------------------------------------------------------------------
+  // Security Groups
+  // -----------------------------------------------------------------------
+
+  async listGroups(
+    opts?: ModelSecurityGroupListOptions,
+  ): Promise<{ totalItems: number; groups: ModelSecurityGroup[] }> {
+    const sdkOpts: Record<string, unknown> = {};
+    if (opts?.sourceTypes) sdkOpts.source_types = opts.sourceTypes;
+    if (opts?.searchQuery) sdkOpts.search_query = opts.searchQuery;
+    if (opts?.sortField) sdkOpts.sort_field = opts.sortField;
+    if (opts?.sortDir) sdkOpts.sort_dir = opts.sortDir;
+    if (opts?.enabledRules) sdkOpts.enabled_rules = opts.enabledRules;
+    if (opts?.skip !== undefined) sdkOpts.skip = opts.skip;
+    if (opts?.limit !== undefined) sdkOpts.limit = opts.limit;
+
+    const response = await this.client.securityGroups.list(sdkOpts as never);
+    const raw = response as unknown as {
+      pagination: { total_items?: number };
+      security_groups: Array<Record<string, unknown>>;
+    };
+    return {
+      totalItems: raw.pagination.total_items ?? 0,
+      groups: raw.security_groups.map(normalizeGroup),
+    };
+  }
+
+  async getGroup(uuid: string): Promise<ModelSecurityGroup> {
+    const response = await this.client.securityGroups.get(uuid);
+    return normalizeGroup(response as unknown as Record<string, unknown>);
+  }
+
+  async createGroup(request: ModelSecurityGroupCreateRequest): Promise<ModelSecurityGroup> {
+    const sdkRequest: Record<string, unknown> = {
+      name: request.name,
+      source_type: request.sourceType,
+    };
+    if (request.description !== undefined) sdkRequest.description = request.description;
+    if (request.ruleConfigurations) sdkRequest.rule_configurations = request.ruleConfigurations;
+
+    const response = await this.client.securityGroups.create(sdkRequest as never);
+    return normalizeGroup(response as unknown as Record<string, unknown>);
+  }
+
+  async updateGroup(
+    uuid: string,
+    request: ModelSecurityGroupUpdateRequest,
+  ): Promise<ModelSecurityGroup> {
+    const response = await this.client.securityGroups.update(uuid, request as never);
+    return normalizeGroup(response as unknown as Record<string, unknown>);
+  }
+
+  async deleteGroup(uuid: string): Promise<void> {
+    await this.client.securityGroups.delete(uuid);
+  }
+
+  // -----------------------------------------------------------------------
+  // Rule Instances
+  // -----------------------------------------------------------------------
+
+  async listRuleInstances(
+    groupUuid: string,
+    opts?: ModelSecurityRuleInstanceListOptions,
+  ): Promise<{ totalItems: number; ruleInstances: ModelSecurityRuleInstance[] }> {
+    const sdkOpts: Record<string, unknown> = {};
+    if (opts?.securityRuleUuid) sdkOpts.security_rule_uuid = opts.securityRuleUuid;
+    if (opts?.state) sdkOpts.state = opts.state;
+    if (opts?.skip !== undefined) sdkOpts.skip = opts.skip;
+    if (opts?.limit !== undefined) sdkOpts.limit = opts.limit;
+
+    const response = await this.client.securityGroups.listRuleInstances(
+      groupUuid,
+      sdkOpts as never,
+    );
+    const raw = response as unknown as {
+      pagination: { total_items?: number };
+      rule_instances: Array<Record<string, unknown>>;
+    };
+    return {
+      totalItems: raw.pagination.total_items ?? 0,
+      ruleInstances: raw.rule_instances.map(normalizeRuleInstance),
+    };
+  }
+
+  async getRuleInstance(
+    groupUuid: string,
+    instanceUuid: string,
+  ): Promise<ModelSecurityRuleInstance> {
+    const response = await this.client.securityGroups.getRuleInstance(groupUuid, instanceUuid);
+    return normalizeRuleInstance(response as unknown as Record<string, unknown>);
+  }
+
+  async updateRuleInstance(
+    groupUuid: string,
+    instanceUuid: string,
+    request: ModelSecurityRuleInstanceUpdateRequest,
+  ): Promise<ModelSecurityRuleInstance> {
+    const sdkRequest: Record<string, unknown> = {
+      security_group_uuid: groupUuid,
+    };
+    if (request.state !== undefined) sdkRequest.state = request.state;
+    if (request.fieldValues !== undefined) sdkRequest.field_values = request.fieldValues;
+
+    const response = await this.client.securityGroups.updateRuleInstance(
+      groupUuid,
+      instanceUuid,
+      sdkRequest as never,
+    );
+    return normalizeRuleInstance(response as unknown as Record<string, unknown>);
+  }
+
+  // -----------------------------------------------------------------------
+  // Security Rules
+  // -----------------------------------------------------------------------
+
+  async listRules(
+    opts?: ModelSecurityRuleListOptions,
+  ): Promise<{ totalItems: number; rules: ModelSecurityRule[] }> {
+    const sdkOpts: Record<string, unknown> = {};
+    if (opts?.sourceType) sdkOpts.source_type = opts.sourceType;
+    if (opts?.searchQuery) sdkOpts.search_query = opts.searchQuery;
+    if (opts?.skip !== undefined) sdkOpts.skip = opts.skip;
+    if (opts?.limit !== undefined) sdkOpts.limit = opts.limit;
+
+    const response = await this.client.securityRules.list(sdkOpts as never);
+    const raw = response as unknown as {
+      pagination: { total_items?: number };
+      rules: Array<Record<string, unknown>>;
+    };
+    return {
+      totalItems: raw.pagination.total_items ?? 0,
+      rules: raw.rules.map(normalizeRule),
+    };
+  }
+
+  async getRule(uuid: string): Promise<ModelSecurityRule> {
+    const response = await this.client.securityRules.get(uuid);
+    return normalizeRule(response as unknown as Record<string, unknown>);
+  }
+
+  // -----------------------------------------------------------------------
+  // Scans
+  // -----------------------------------------------------------------------
+
+  async createScan(request: Record<string, unknown>): Promise<ModelSecurityScan> {
+    const response = await this.client.scans.create(request as never);
+    return normalizeScan(response as unknown as Record<string, unknown>);
+  }
+
+  async listScans(
+    opts?: ModelSecurityScanListOptions,
+  ): Promise<{ totalItems: number; scans: ModelSecurityScan[] }> {
+    const sdkOpts: Record<string, unknown> = {};
+    if (opts?.evalOutcome) sdkOpts.eval_outcome = opts.evalOutcome;
+    if (opts?.sourceType) sdkOpts.source_type = opts.sourceType;
+    if (opts?.scanOrigin) sdkOpts.scan_origin = opts.scanOrigin;
+    if (opts?.search) sdkOpts.search = opts.search;
+    if (opts?.skip !== undefined) sdkOpts.skip = opts.skip;
+    if (opts?.limit !== undefined) sdkOpts.limit = opts.limit;
+
+    const response = await this.client.scans.list(sdkOpts as never);
+    const raw = response as unknown as {
+      pagination: { total_items?: number };
+      scans: Array<Record<string, unknown>>;
+    };
+    return {
+      totalItems: raw.pagination.total_items ?? 0,
+      scans: raw.scans.map(normalizeScan),
+    };
+  }
+
+  async getScan(uuid: string): Promise<ModelSecurityScan> {
+    const response = await this.client.scans.get(uuid);
+    return normalizeScan(response as unknown as Record<string, unknown>);
+  }
+
+  // -----------------------------------------------------------------------
+  // Evaluations
+  // -----------------------------------------------------------------------
+
+  async getEvaluations(
+    scanUuid: string,
+    opts?: { skip?: number; limit?: number },
+  ): Promise<{ totalItems: number; evaluations: ModelSecurityEvaluation[] }> {
+    const response = await this.client.scans.getEvaluations(scanUuid, opts as never);
+    const raw = response as unknown as {
+      pagination: { total_items?: number };
+      evaluations: Array<Record<string, unknown>>;
+    };
+    return {
+      totalItems: raw.pagination.total_items ?? 0,
+      evaluations: raw.evaluations.map(normalizeEvaluation),
+    };
+  }
+
+  async getEvaluation(uuid: string): Promise<ModelSecurityEvaluation> {
+    const response = await this.client.scans.getEvaluation(uuid);
+    return normalizeEvaluation(response as unknown as Record<string, unknown>);
+  }
+
+  // -----------------------------------------------------------------------
+  // Violations
+  // -----------------------------------------------------------------------
+
+  async getViolations(
+    scanUuid: string,
+    opts?: { skip?: number; limit?: number },
+  ): Promise<{ totalItems: number; violations: ModelSecurityViolation[] }> {
+    const response = await this.client.scans.getViolations(scanUuid, opts as never);
+    const raw = response as unknown as {
+      pagination: { total_items?: number };
+      violations: Array<Record<string, unknown>>;
+    };
+    return {
+      totalItems: raw.pagination.total_items ?? 0,
+      violations: raw.violations.map(normalizeViolation),
+    };
+  }
+
+  async getViolation(uuid: string): Promise<ModelSecurityViolation> {
+    const response = await this.client.scans.getViolation(uuid);
+    return normalizeViolation(response as unknown as Record<string, unknown>);
+  }
+
+  // -----------------------------------------------------------------------
+  // Files
+  // -----------------------------------------------------------------------
+
+  async getFiles(
+    scanUuid: string,
+    opts?: ModelSecurityFileListOptions,
+  ): Promise<{ totalItems: number; files: ModelSecurityFile[] }> {
+    const response = await this.client.scans.getFiles(scanUuid, opts as never);
+    const raw = response as unknown as {
+      pagination: { total_items?: number };
+      files: Array<Record<string, unknown>>;
+    };
+    return {
+      totalItems: raw.pagination.total_items ?? 0,
+      files: raw.files.map(normalizeFile),
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // Labels
+  // -----------------------------------------------------------------------
+
+  async addLabels(scanUuid: string, labels: ModelSecurityLabel[]): Promise<void> {
+    await this.client.scans.addLabels(scanUuid, { labels } as never);
+  }
+
+  async setLabels(scanUuid: string, labels: ModelSecurityLabel[]): Promise<void> {
+    await this.client.scans.setLabels(scanUuid, { labels } as never);
+  }
+
+  async deleteLabels(scanUuid: string, keys: string[]): Promise<void> {
+    await this.client.scans.deleteLabels(scanUuid, keys);
+  }
+
+  async getLabelKeys(opts?: {
+    skip?: number;
+    limit?: number;
+  }): Promise<{ totalItems: number; keys: string[] }> {
+    const response = await this.client.scans.getLabelKeys(opts as never);
+    const raw = response as unknown as {
+      pagination: { total_items?: number };
+      keys: string[];
+    };
+    return {
+      totalItems: raw.pagination.total_items ?? 0,
+      keys: raw.keys,
+    };
+  }
+
+  async getLabelValues(
+    key: string,
+    opts?: { skip?: number; limit?: number },
+  ): Promise<{ totalItems: number; values: string[] }> {
+    const response = await this.client.scans.getLabelValues(key, opts as never);
+    const raw = response as unknown as {
+      pagination: { total_items?: number };
+      values: string[];
+    };
+    return {
+      totalItems: raw.pagination.total_items ?? 0,
+      values: raw.values,
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // PyPI Auth
+  // -----------------------------------------------------------------------
+
+  async getPyPIAuth(): Promise<ModelSecurityPyPIAuth> {
+    const response = await this.client.getPyPIAuth();
+    const raw = response as unknown as Record<string, unknown>;
+    return {
+      url: raw.url as string,
+      expiresAt: raw.expires_at as string,
+    };
+  }
+}

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -369,6 +369,246 @@ export interface RedTeamService {
 }
 
 // ---------------------------------------------------------------------------
+// Model Security types — normalized shapes for model security operations
+// ---------------------------------------------------------------------------
+
+/** Normalized security group. */
+export interface ModelSecurityGroup {
+  uuid: string;
+  name: string;
+  description: string;
+  sourceType: string;
+  state: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Request to create a security group. */
+export interface ModelSecurityGroupCreateRequest {
+  name: string;
+  sourceType: string;
+  description?: string;
+  ruleConfigurations?: Record<string, Record<string, unknown>>;
+}
+
+/** Request to update a security group. */
+export interface ModelSecurityGroupUpdateRequest {
+  name?: string;
+  description?: string;
+}
+
+/** Filter options for listing security groups. */
+export interface ModelSecurityGroupListOptions {
+  sourceTypes?: string[];
+  searchQuery?: string;
+  sortField?: string;
+  sortDir?: string;
+  enabledRules?: string[];
+  skip?: number;
+  limit?: number;
+}
+
+/** Normalized security rule. */
+export interface ModelSecurityRule {
+  uuid: string;
+  name: string;
+  description: string;
+  ruleType: string;
+  compatibleSources: string[];
+  defaultState: string;
+  remediation: {
+    description: string;
+    steps: string[];
+    url: string;
+  };
+  editableFields: ModelSecurityRuleEditableField[];
+  constantValues: Record<string, unknown>;
+  defaultValues: Record<string, unknown>;
+}
+
+/** Editable field spec for a security rule. */
+export interface ModelSecurityRuleEditableField {
+  attributeName: string;
+  type: string;
+  displayName: string;
+  displayType: string;
+  description?: string;
+  dropdownValues?: Array<{ value: string; label: string }>;
+}
+
+/** Filter options for listing security rules. */
+export interface ModelSecurityRuleListOptions {
+  sourceType?: string;
+  searchQuery?: string;
+  skip?: number;
+  limit?: number;
+}
+
+/** Normalized rule instance within a security group. */
+export interface ModelSecurityRuleInstance {
+  uuid: string;
+  securityGroupUuid: string;
+  securityRuleUuid: string;
+  state: string;
+  createdAt: string;
+  updatedAt: string;
+  rule: Record<string, unknown>;
+  fieldValues: Record<string, unknown>;
+}
+
+/** Filter options for listing rule instances. */
+export interface ModelSecurityRuleInstanceListOptions {
+  securityRuleUuid?: string;
+  state?: string;
+  skip?: number;
+  limit?: number;
+}
+
+/** Request to update a rule instance. */
+export interface ModelSecurityRuleInstanceUpdateRequest {
+  state?: string;
+  fieldValues?: Record<string, unknown>;
+}
+
+/** Normalized model security scan. */
+export interface ModelSecurityScan {
+  uuid: string;
+  status: string;
+  evalSummary: {
+    rulesFailed: number;
+    rulesPassed: number;
+    totalRules: number;
+  } | null;
+  createdAt: string;
+  updatedAt: string;
+  labels: Array<{ key: string; value: string }>;
+}
+
+/** Filter options for listing scans. */
+export interface ModelSecurityScanListOptions {
+  evalOutcome?: string;
+  sourceType?: string;
+  scanOrigin?: string;
+  search?: string;
+  skip?: number;
+  limit?: number;
+}
+
+/** Normalized rule evaluation from a scan. */
+export interface ModelSecurityEvaluation {
+  uuid: string;
+  evalOutcome: string;
+  result: string;
+  securityRuleUuid: string;
+  ruleName: string;
+}
+
+/** Normalized violation from a scan. */
+export interface ModelSecurityViolation {
+  uuid: string;
+  ruleName: string;
+  filePath: string;
+  description: string;
+}
+
+/** Normalized scanned file from a scan. */
+export interface ModelSecurityFile {
+  filePath: string;
+  type: string;
+  result: string;
+}
+
+/** Filter options for listing scanned files. */
+export interface ModelSecurityFileListOptions {
+  type?: string;
+  result?: string;
+  skip?: number;
+  limit?: number;
+}
+
+/** Label key-value pair. */
+export interface ModelSecurityLabel {
+  key: string;
+  value: string;
+}
+
+/** PyPI authentication response. */
+export interface ModelSecurityPyPIAuth {
+  url: string;
+  expiresAt: string;
+}
+
+/** Paginated list result. */
+export interface PaginatedResult<T> {
+  totalItems: number;
+  [key: string]: T[] | number;
+}
+
+/** Contract for Model Security operations. */
+export interface ModelSecurityService {
+  listGroups(
+    opts?: ModelSecurityGroupListOptions,
+  ): Promise<{ totalItems: number; groups: ModelSecurityGroup[] }>;
+  getGroup(uuid: string): Promise<ModelSecurityGroup>;
+  createGroup(request: ModelSecurityGroupCreateRequest): Promise<ModelSecurityGroup>;
+  updateGroup(uuid: string, request: ModelSecurityGroupUpdateRequest): Promise<ModelSecurityGroup>;
+  deleteGroup(uuid: string): Promise<void>;
+
+  listRuleInstances(
+    groupUuid: string,
+    opts?: ModelSecurityRuleInstanceListOptions,
+  ): Promise<{ totalItems: number; ruleInstances: ModelSecurityRuleInstance[] }>;
+  getRuleInstance(groupUuid: string, instanceUuid: string): Promise<ModelSecurityRuleInstance>;
+  updateRuleInstance(
+    groupUuid: string,
+    instanceUuid: string,
+    request: ModelSecurityRuleInstanceUpdateRequest,
+  ): Promise<ModelSecurityRuleInstance>;
+
+  listRules(
+    opts?: ModelSecurityRuleListOptions,
+  ): Promise<{ totalItems: number; rules: ModelSecurityRule[] }>;
+  getRule(uuid: string): Promise<ModelSecurityRule>;
+
+  createScan(request: Record<string, unknown>): Promise<ModelSecurityScan>;
+  listScans(
+    opts?: ModelSecurityScanListOptions,
+  ): Promise<{ totalItems: number; scans: ModelSecurityScan[] }>;
+  getScan(uuid: string): Promise<ModelSecurityScan>;
+
+  getEvaluations(
+    scanUuid: string,
+    opts?: { skip?: number; limit?: number },
+  ): Promise<{ totalItems: number; evaluations: ModelSecurityEvaluation[] }>;
+  getEvaluation(uuid: string): Promise<ModelSecurityEvaluation>;
+
+  getViolations(
+    scanUuid: string,
+    opts?: { skip?: number; limit?: number },
+  ): Promise<{ totalItems: number; violations: ModelSecurityViolation[] }>;
+  getViolation(uuid: string): Promise<ModelSecurityViolation>;
+
+  getFiles(
+    scanUuid: string,
+    opts?: ModelSecurityFileListOptions,
+  ): Promise<{ totalItems: number; files: ModelSecurityFile[] }>;
+
+  addLabels(scanUuid: string, labels: ModelSecurityLabel[]): Promise<void>;
+  setLabels(scanUuid: string, labels: ModelSecurityLabel[]): Promise<void>;
+  deleteLabels(scanUuid: string, keys: string[]): Promise<void>;
+  getLabelKeys(opts?: {
+    skip?: number;
+    limit?: number;
+  }): Promise<{ totalItems: number; keys: string[] }>;
+  getLabelValues(
+    key: string,
+    opts?: { skip?: number; limit?: number },
+  ): Promise<{ totalItems: number; values: string[] }>;
+
+  getPyPIAuth(): Promise<ModelSecurityPyPIAuth>;
+}
+
+// ---------------------------------------------------------------------------
 // Management service interface
 // ---------------------------------------------------------------------------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@
 // AIRS integration — scan prompts and manage topics/profiles via SDK
 // ---------------------------------------------------------------------------
 export { SdkManagementService } from './airs/management.js';
+export { SdkModelSecurityService } from './airs/modelsecurity.js';
 export { SdkPromptSetService } from './airs/promptsets.js';
 export { SdkRedTeamService } from './airs/redteam.js';
 export { AirsScanService } from './airs/scanner.js';
@@ -16,6 +17,25 @@ export { AirsScanService } from './airs/scanner.js';
 // Core loop & metrics — the main generate→test→evaluate→improve cycle
 // ---------------------------------------------------------------------------
 export type {
+  ModelSecurityEvaluation,
+  ModelSecurityFile,
+  ModelSecurityFileListOptions,
+  ModelSecurityGroup,
+  ModelSecurityGroupCreateRequest,
+  ModelSecurityGroupListOptions,
+  ModelSecurityGroupUpdateRequest,
+  ModelSecurityLabel,
+  ModelSecurityPyPIAuth,
+  ModelSecurityRule,
+  ModelSecurityRuleEditableField,
+  ModelSecurityRuleInstance,
+  ModelSecurityRuleInstanceListOptions,
+  ModelSecurityRuleInstanceUpdateRequest,
+  ModelSecurityRuleListOptions,
+  ModelSecurityScan,
+  ModelSecurityScanListOptions,
+  ModelSecurityService,
+  ModelSecurityViolation,
   PromptDetail,
   PromptSetDetail,
   PromptSetService,

--- a/tests/unit/airs/modelsecurity.spec.ts
+++ b/tests/unit/airs/modelsecurity.spec.ts
@@ -1,0 +1,722 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SdkModelSecurityService } from '../../../src/airs/modelsecurity.js';
+
+// -- Mock fns for ModelSecurityClient sub-clients --
+const mockScansCreate = vi.fn();
+const mockScansList = vi.fn();
+const mockScansGet = vi.fn();
+const mockScansGetEvaluations = vi.fn();
+const mockScansGetEvaluation = vi.fn();
+const mockScansGetViolations = vi.fn();
+const mockScansGetViolation = vi.fn();
+const mockScansGetFiles = vi.fn();
+const mockScansAddLabels = vi.fn();
+const mockScansSetLabels = vi.fn();
+const mockScansDeleteLabels = vi.fn();
+const mockScansGetLabelKeys = vi.fn();
+const mockScansGetLabelValues = vi.fn();
+
+const mockGroupsCreate = vi.fn();
+const mockGroupsList = vi.fn();
+const mockGroupsGet = vi.fn();
+const mockGroupsUpdate = vi.fn();
+const mockGroupsDelete = vi.fn();
+const mockGroupsListRuleInstances = vi.fn();
+const mockGroupsGetRuleInstance = vi.fn();
+const mockGroupsUpdateRuleInstance = vi.fn();
+
+const mockRulesList = vi.fn();
+const mockRulesGet = vi.fn();
+
+const mockGetPyPIAuth = vi.fn();
+
+function makeMockClient() {
+  return {
+    scans: {
+      create: mockScansCreate,
+      list: mockScansList,
+      get: mockScansGet,
+      getEvaluations: mockScansGetEvaluations,
+      getEvaluation: mockScansGetEvaluation,
+      getViolations: mockScansGetViolations,
+      getViolation: mockScansGetViolation,
+      getFiles: mockScansGetFiles,
+      addLabels: mockScansAddLabels,
+      setLabels: mockScansSetLabels,
+      deleteLabels: mockScansDeleteLabels,
+      getLabelKeys: mockScansGetLabelKeys,
+      getLabelValues: mockScansGetLabelValues,
+    },
+    securityGroups: {
+      create: mockGroupsCreate,
+      list: mockGroupsList,
+      get: mockGroupsGet,
+      update: mockGroupsUpdate,
+      delete: mockGroupsDelete,
+      listRuleInstances: mockGroupsListRuleInstances,
+      getRuleInstance: mockGroupsGetRuleInstance,
+      updateRuleInstance: mockGroupsUpdateRuleInstance,
+    },
+    securityRules: {
+      list: mockRulesList,
+      get: mockRulesGet,
+    },
+    getPyPIAuth: mockGetPyPIAuth,
+  };
+}
+
+vi.mock('@cdot65/prisma-airs-sdk', () => ({
+  ModelSecurityClient: vi.fn().mockImplementation(() => makeMockClient()),
+}));
+
+describe('SdkModelSecurityService', () => {
+  let service: SdkModelSecurityService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new SdkModelSecurityService({
+      clientId: 'test-id',
+      clientSecret: 'test-secret',
+      tsgId: 'tsg-123',
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Security Groups
+  // -----------------------------------------------------------------------
+  describe('listGroups', () => {
+    it('returns normalized group list', async () => {
+      mockGroupsList.mockResolvedValue({
+        pagination: { total_items: 2 },
+        security_groups: [
+          {
+            uuid: 'g-1',
+            name: 'Group 1',
+            description: 'First group',
+            source_type: 'HUGGING_FACE',
+            state: 'ACTIVE',
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+          },
+          {
+            uuid: 'g-2',
+            name: 'Group 2',
+            description: '',
+            source_type: 'LOCAL',
+            state: 'PENDING',
+            created_at: '2026-01-03T00:00:00Z',
+            updated_at: '2026-01-04T00:00:00Z',
+          },
+        ],
+      });
+
+      const result = await service.listGroups();
+      expect(result.totalItems).toBe(2);
+      expect(result.groups).toEqual([
+        {
+          uuid: 'g-1',
+          name: 'Group 1',
+          description: 'First group',
+          sourceType: 'HUGGING_FACE',
+          state: 'ACTIVE',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-02T00:00:00Z',
+        },
+        {
+          uuid: 'g-2',
+          name: 'Group 2',
+          description: '',
+          sourceType: 'LOCAL',
+          state: 'PENDING',
+          createdAt: '2026-01-03T00:00:00Z',
+          updatedAt: '2026-01-04T00:00:00Z',
+        },
+      ]);
+    });
+
+    it('passes filter options through', async () => {
+      mockGroupsList.mockResolvedValue({
+        pagination: { total_items: 0 },
+        security_groups: [],
+      });
+
+      await service.listGroups({
+        sourceTypes: ['HUGGING_FACE'],
+        searchQuery: 'prod',
+        sortField: 'created_at',
+        sortDir: 'desc',
+        enabledRules: ['r-1'],
+        limit: 5,
+      });
+
+      expect(mockGroupsList).toHaveBeenCalledWith({
+        source_types: ['HUGGING_FACE'],
+        search_query: 'prod',
+        sort_field: 'created_at',
+        sort_dir: 'desc',
+        enabled_rules: ['r-1'],
+        limit: 5,
+      });
+    });
+  });
+
+  describe('getGroup', () => {
+    it('returns normalized group detail', async () => {
+      mockGroupsGet.mockResolvedValue({
+        uuid: 'g-1',
+        name: 'Group 1',
+        description: 'desc',
+        source_type: 'S3',
+        state: 'ACTIVE',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z',
+      });
+
+      const result = await service.getGroup('g-1');
+      expect(result.uuid).toBe('g-1');
+      expect(result.sourceType).toBe('S3');
+    });
+  });
+
+  describe('createGroup', () => {
+    it('returns normalized created group', async () => {
+      mockGroupsCreate.mockResolvedValue({
+        uuid: 'g-new',
+        name: 'New Group',
+        description: 'desc',
+        source_type: 'HUGGING_FACE',
+        state: 'PENDING',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      });
+
+      const result = await service.createGroup({
+        name: 'New Group',
+        sourceType: 'HUGGING_FACE',
+        description: 'desc',
+      });
+
+      expect(result.uuid).toBe('g-new');
+      expect(mockGroupsCreate).toHaveBeenCalledWith({
+        name: 'New Group',
+        source_type: 'HUGGING_FACE',
+        description: 'desc',
+      });
+    });
+
+    it('passes rule configurations', async () => {
+      mockGroupsCreate.mockResolvedValue({
+        uuid: 'g-new',
+        name: 'G',
+        description: '',
+        source_type: 'LOCAL',
+        state: 'PENDING',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      });
+
+      await service.createGroup({
+        name: 'G',
+        sourceType: 'LOCAL',
+        ruleConfigurations: { 'r-1': { state: 'BLOCKING' } },
+      });
+
+      expect(mockGroupsCreate).toHaveBeenCalledWith({
+        name: 'G',
+        source_type: 'LOCAL',
+        rule_configurations: { 'r-1': { state: 'BLOCKING' } },
+      });
+    });
+  });
+
+  describe('updateGroup', () => {
+    it('returns normalized updated group', async () => {
+      mockGroupsUpdate.mockResolvedValue({
+        uuid: 'g-1',
+        name: 'Updated',
+        description: 'new desc',
+        source_type: 'LOCAL',
+        state: 'ACTIVE',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-05T00:00:00Z',
+      });
+
+      const result = await service.updateGroup('g-1', { name: 'Updated', description: 'new desc' });
+      expect(result.name).toBe('Updated');
+      expect(mockGroupsUpdate).toHaveBeenCalledWith('g-1', {
+        name: 'Updated',
+        description: 'new desc',
+      });
+    });
+  });
+
+  describe('deleteGroup', () => {
+    it('calls SDK delete', async () => {
+      mockGroupsDelete.mockResolvedValue(undefined);
+      await service.deleteGroup('g-1');
+      expect(mockGroupsDelete).toHaveBeenCalledWith('g-1');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Rule Instances
+  // -----------------------------------------------------------------------
+  describe('listRuleInstances', () => {
+    it('returns normalized rule instance list', async () => {
+      mockGroupsListRuleInstances.mockResolvedValue({
+        pagination: { total_items: 1 },
+        rule_instances: [
+          {
+            uuid: 'ri-1',
+            security_group_uuid: 'g-1',
+            security_rule_uuid: 'r-1',
+            state: 'BLOCKING',
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            rule: { uuid: 'r-1', name: 'Rule 1' },
+            field_values: { approved_formats: ['safetensors'] },
+          },
+        ],
+      });
+
+      const result = await service.listRuleInstances('g-1');
+      expect(result.totalItems).toBe(1);
+      expect(result.ruleInstances[0]).toEqual({
+        uuid: 'ri-1',
+        securityGroupUuid: 'g-1',
+        securityRuleUuid: 'r-1',
+        state: 'BLOCKING',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-02T00:00:00Z',
+        rule: { uuid: 'r-1', name: 'Rule 1' },
+        fieldValues: { approved_formats: ['safetensors'] },
+      });
+    });
+
+    it('passes filter options', async () => {
+      mockGroupsListRuleInstances.mockResolvedValue({
+        pagination: { total_items: 0 },
+        rule_instances: [],
+      });
+
+      await service.listRuleInstances('g-1', {
+        securityRuleUuid: 'r-1',
+        state: 'BLOCKING',
+      });
+
+      expect(mockGroupsListRuleInstances).toHaveBeenCalledWith('g-1', {
+        security_rule_uuid: 'r-1',
+        state: 'BLOCKING',
+      });
+    });
+  });
+
+  describe('getRuleInstance', () => {
+    it('returns normalized rule instance', async () => {
+      mockGroupsGetRuleInstance.mockResolvedValue({
+        uuid: 'ri-1',
+        security_group_uuid: 'g-1',
+        security_rule_uuid: 'r-1',
+        state: 'ALLOWING',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z',
+        rule: { uuid: 'r-1', name: 'Rule 1' },
+        field_values: {},
+      });
+
+      const result = await service.getRuleInstance('g-1', 'ri-1');
+      expect(result.uuid).toBe('ri-1');
+      expect(result.state).toBe('ALLOWING');
+    });
+  });
+
+  describe('updateRuleInstance', () => {
+    it('passes request to SDK and returns normalized result', async () => {
+      mockGroupsUpdateRuleInstance.mockResolvedValue({
+        uuid: 'ri-1',
+        security_group_uuid: 'g-1',
+        security_rule_uuid: 'r-1',
+        state: 'BLOCKING',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-03T00:00:00Z',
+        rule: { uuid: 'r-1', name: 'Rule 1' },
+        field_values: { approved_formats: ['onnx'] },
+      });
+
+      const result = await service.updateRuleInstance('g-1', 'ri-1', {
+        state: 'BLOCKING',
+        fieldValues: { approved_formats: ['onnx'] },
+      });
+
+      expect(result.state).toBe('BLOCKING');
+      expect(mockGroupsUpdateRuleInstance).toHaveBeenCalledWith('g-1', 'ri-1', {
+        security_group_uuid: 'g-1',
+        state: 'BLOCKING',
+        field_values: { approved_formats: ['onnx'] },
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Security Rules
+  // -----------------------------------------------------------------------
+  describe('listRules', () => {
+    it('returns normalized rule list', async () => {
+      mockRulesList.mockResolvedValue({
+        pagination: { total_items: 1 },
+        rules: [
+          {
+            uuid: 'r-1',
+            name: 'Approved Formats',
+            description: 'Check model formats',
+            rule_type: 'ARTIFACT',
+            compatible_sources: ['HUGGING_FACE', 'LOCAL'],
+            default_state: 'ALLOWING',
+            remediation: {
+              description: 'Fix format',
+              steps: ['Step 1'],
+              url: 'https://example.com',
+            },
+            editable_fields: [],
+            constant_values: {},
+            default_values: {},
+          },
+        ],
+      });
+
+      const result = await service.listRules();
+      expect(result.totalItems).toBe(1);
+      expect(result.rules[0]).toEqual({
+        uuid: 'r-1',
+        name: 'Approved Formats',
+        description: 'Check model formats',
+        ruleType: 'ARTIFACT',
+        compatibleSources: ['HUGGING_FACE', 'LOCAL'],
+        defaultState: 'ALLOWING',
+        remediation: { description: 'Fix format', steps: ['Step 1'], url: 'https://example.com' },
+        editableFields: [],
+        constantValues: {},
+        defaultValues: {},
+      });
+    });
+
+    it('passes filter options', async () => {
+      mockRulesList.mockResolvedValue({ pagination: { total_items: 0 }, rules: [] });
+
+      await service.listRules({ sourceType: 'LOCAL', searchQuery: 'format' });
+
+      expect(mockRulesList).toHaveBeenCalledWith({
+        source_type: 'LOCAL',
+        search_query: 'format',
+      });
+    });
+  });
+
+  describe('getRule', () => {
+    it('returns normalized rule', async () => {
+      mockRulesGet.mockResolvedValue({
+        uuid: 'r-1',
+        name: 'Rule',
+        description: 'desc',
+        rule_type: 'METADATA',
+        compatible_sources: ['S3'],
+        default_state: 'DISABLED',
+        remediation: { description: '', steps: [], url: '' },
+        editable_fields: [
+          {
+            attribute_name: 'approved_licenses',
+            type: 'string',
+            display_name: 'Approved Licenses',
+            display_type: 'LIST',
+          },
+        ],
+        constant_values: {},
+        default_values: { approved_licenses: [] },
+      });
+
+      const result = await service.getRule('r-1');
+      expect(result.ruleType).toBe('METADATA');
+      expect(result.editableFields).toHaveLength(1);
+      expect(result.editableFields[0].attributeName).toBe('approved_licenses');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Scans
+  // -----------------------------------------------------------------------
+  describe('listScans', () => {
+    it('returns normalized scan list', async () => {
+      mockScansList.mockResolvedValue({
+        pagination: { total_items: 1 },
+        scans: [
+          {
+            uuid: 's-1',
+            status: 'COMPLETED',
+            eval_summary: { rules_failed: 1, rules_passed: 5, total_rules: 6 },
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-02T00:00:00Z',
+            labels: [{ key: 'env', value: 'prod' }],
+          },
+        ],
+      });
+
+      const result = await service.listScans();
+      expect(result.totalItems).toBe(1);
+      expect(result.scans[0]).toEqual({
+        uuid: 's-1',
+        status: 'COMPLETED',
+        evalSummary: { rulesFailed: 1, rulesPassed: 5, totalRules: 6 },
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-02T00:00:00Z',
+        labels: [{ key: 'env', value: 'prod' }],
+      });
+    });
+
+    it('passes filter options', async () => {
+      mockScansList.mockResolvedValue({ pagination: { total_items: 0 }, scans: [] });
+
+      await service.listScans({
+        evalOutcome: 'BLOCKED',
+        sourceType: 'HUGGING_FACE',
+        scanOrigin: 'MODEL_SECURITY_SDK',
+        limit: 10,
+      });
+
+      expect(mockScansList).toHaveBeenCalledWith({
+        eval_outcome: 'BLOCKED',
+        source_type: 'HUGGING_FACE',
+        scan_origin: 'MODEL_SECURITY_SDK',
+        limit: 10,
+      });
+    });
+  });
+
+  describe('getScan', () => {
+    it('returns normalized scan', async () => {
+      mockScansGet.mockResolvedValue({
+        uuid: 's-1',
+        status: 'COMPLETED',
+        eval_summary: { rules_failed: 0, rules_passed: 3, total_rules: 3 },
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z',
+        labels: [],
+      });
+
+      const result = await service.getScan('s-1');
+      expect(result.uuid).toBe('s-1');
+      expect(result.evalSummary.totalRules).toBe(3);
+    });
+  });
+
+  describe('createScan', () => {
+    it('passes request to SDK and returns normalized result', async () => {
+      mockScansCreate.mockResolvedValue({
+        uuid: 's-new',
+        status: 'PENDING',
+        eval_summary: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        labels: [],
+      });
+
+      const result = await service.createScan({ someField: 'value' });
+      expect(result.uuid).toBe('s-new');
+      expect(mockScansCreate).toHaveBeenCalledWith({ someField: 'value' });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Evaluations
+  // -----------------------------------------------------------------------
+  describe('getEvaluations', () => {
+    it('returns normalized evaluation list', async () => {
+      mockScansGetEvaluations.mockResolvedValue({
+        pagination: { total_items: 1 },
+        evaluations: [
+          {
+            uuid: 'e-1',
+            eval_outcome: 'BLOCKED',
+            result: 'FAILED',
+            security_rule_uuid: 'r-1',
+            rule_name: 'Format Check',
+          },
+        ],
+      });
+
+      const result = await service.getEvaluations('s-1');
+      expect(result.totalItems).toBe(1);
+      expect(result.evaluations[0]).toEqual({
+        uuid: 'e-1',
+        evalOutcome: 'BLOCKED',
+        result: 'FAILED',
+        securityRuleUuid: 'r-1',
+        ruleName: 'Format Check',
+      });
+    });
+  });
+
+  describe('getEvaluation', () => {
+    it('returns normalized single evaluation', async () => {
+      mockScansGetEvaluation.mockResolvedValue({
+        uuid: 'e-1',
+        eval_outcome: 'ALLOWED',
+        result: 'PASSED',
+        security_rule_uuid: 'r-1',
+        rule_name: 'License Check',
+      });
+
+      const result = await service.getEvaluation('e-1');
+      expect(result.evalOutcome).toBe('ALLOWED');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Violations
+  // -----------------------------------------------------------------------
+  describe('getViolations', () => {
+    it('returns normalized violation list', async () => {
+      mockScansGetViolations.mockResolvedValue({
+        pagination: { total_items: 1 },
+        violations: [
+          {
+            uuid: 'v-1',
+            rule_name: 'Malicious Code',
+            file_path: 'model.pkl',
+            description: 'Pickle exploit detected',
+          },
+        ],
+      });
+
+      const result = await service.getViolations('s-1');
+      expect(result.totalItems).toBe(1);
+      expect(result.violations[0]).toEqual({
+        uuid: 'v-1',
+        ruleName: 'Malicious Code',
+        filePath: 'model.pkl',
+        description: 'Pickle exploit detected',
+      });
+    });
+  });
+
+  describe('getViolation', () => {
+    it('returns normalized single violation', async () => {
+      mockScansGetViolation.mockResolvedValue({
+        uuid: 'v-1',
+        rule_name: 'Format Check',
+        file_path: 'model.bin',
+        description: 'Unapproved format',
+      });
+
+      const result = await service.getViolation('v-1');
+      expect(result.uuid).toBe('v-1');
+      expect(result.ruleName).toBe('Format Check');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Files
+  // -----------------------------------------------------------------------
+  describe('getFiles', () => {
+    it('returns normalized file list', async () => {
+      mockScansGetFiles.mockResolvedValue({
+        pagination: { total_items: 1 },
+        files: [
+          {
+            file_path: 'model.safetensors',
+            type: 'FILE',
+            result: 'SUCCESS',
+          },
+        ],
+      });
+
+      const result = await service.getFiles('s-1');
+      expect(result.totalItems).toBe(1);
+      expect(result.files[0]).toEqual({
+        filePath: 'model.safetensors',
+        type: 'FILE',
+        result: 'SUCCESS',
+      });
+    });
+
+    it('passes filter options', async () => {
+      mockScansGetFiles.mockResolvedValue({ pagination: { total_items: 0 }, files: [] });
+
+      await service.getFiles('s-1', { type: 'FILE', result: 'FAILED' });
+
+      expect(mockScansGetFiles).toHaveBeenCalledWith('s-1', { type: 'FILE', result: 'FAILED' });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Labels
+  // -----------------------------------------------------------------------
+  describe('addLabels', () => {
+    it('calls SDK addLabels', async () => {
+      mockScansAddLabels.mockResolvedValue({});
+      await service.addLabels('s-1', [{ key: 'env', value: 'prod' }]);
+      expect(mockScansAddLabels).toHaveBeenCalledWith('s-1', {
+        labels: [{ key: 'env', value: 'prod' }],
+      });
+    });
+  });
+
+  describe('setLabels', () => {
+    it('calls SDK setLabels', async () => {
+      mockScansSetLabels.mockResolvedValue({});
+      await service.setLabels('s-1', [{ key: 'env', value: 'staging' }]);
+      expect(mockScansSetLabels).toHaveBeenCalledWith('s-1', {
+        labels: [{ key: 'env', value: 'staging' }],
+      });
+    });
+  });
+
+  describe('deleteLabels', () => {
+    it('calls SDK deleteLabels', async () => {
+      mockScansDeleteLabels.mockResolvedValue(undefined);
+      await service.deleteLabels('s-1', ['env', 'team']);
+      expect(mockScansDeleteLabels).toHaveBeenCalledWith('s-1', ['env', 'team']);
+    });
+  });
+
+  describe('getLabelKeys', () => {
+    it('returns label keys', async () => {
+      mockScansGetLabelKeys.mockResolvedValue({
+        pagination: { total_items: 2 },
+        keys: ['env', 'team'],
+      });
+
+      const result = await service.getLabelKeys();
+      expect(result).toEqual({ totalItems: 2, keys: ['env', 'team'] });
+    });
+  });
+
+  describe('getLabelValues', () => {
+    it('returns label values for a key', async () => {
+      mockScansGetLabelValues.mockResolvedValue({
+        pagination: { total_items: 2 },
+        values: ['prod', 'staging'],
+      });
+
+      const result = await service.getLabelValues('env');
+      expect(result).toEqual({ totalItems: 2, values: ['prod', 'staging'] });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // PyPI Auth
+  // -----------------------------------------------------------------------
+  describe('getPyPIAuth', () => {
+    it('returns auth response', async () => {
+      mockGetPyPIAuth.mockResolvedValue({
+        url: 'https://pypi.example.com',
+        expires_at: '2026-01-01T01:00:00Z',
+      });
+
+      const result = await service.getPyPIAuth();
+      expect(result).toEqual({
+        url: 'https://pypi.example.com',
+        expiresAt: '2026-01-01T01:00:00Z',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Bump `@cdot65/prisma-airs-sdk` from v0.6.0 to v0.6.1 (new list filter options for security groups, rules, rule instances)
- Add 19 Model Security interfaces to `src/airs/types.ts` — groups, rules, rule instances, scans, evaluations, violations, files, labels
- Add `SdkModelSecurityService` wrapping `ModelSecurityClient` with full snake_case → camelCase normalization
- Export service class + all types from public API (`src/index.ts`)
- 30 new tests (390 total), 100% coverage on `modelsecurity.ts`

Closes #53

## Test plan
- [x] 390 tests pass (30 new for model security service)
- [x] `pnpm run lint` — no violations
- [x] `pnpm run format:check` — no violations
- [x] `pnpm tsc --noEmit` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)