### PR TITLE
feat: model security CLI — groups, rules, rule-instances

### DIFF
--- a/docs/examples/model-security.md
+++ b/docs/examples/model-security.md
@@ -1,0 +1,233 @@
+# Model Security Operations
+
+This guide walks through managing AI Model Security using the `daystrom model-security` command group — security groups, rules, and rule instances.
+
+---
+
+## Security Groups
+
+### List groups
+
+```bash
+daystrom model-security groups list
+```
+
+```
+  Prisma AIRS — Model Security
+  ML model supply chain security
+
+  Security Groups:
+
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Default GCS Group  ACTIVE  source: GCS
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Default LOCAL Group  ACTIVE  source: LOCAL
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Default S3 Group  ACTIVE  source: S3
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Default AZURE Group  ACTIVE  source: AZURE
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Default HUGGING_FACE Group  ACTIVE  source: HUGGING_FACE
+```
+
+### Filter groups
+
+```bash
+# By source type
+daystrom model-security groups list --source-types LOCAL,S3
+
+# Search by name
+daystrom model-security groups list --search "Default"
+
+# Sort by creation date
+daystrom model-security groups list --sort-field created_at --sort-dir desc
+```
+
+### Get group details
+
+```bash
+daystrom model-security groups get <uuid>
+```
+
+```
+  Prisma AIRS — Model Security
+  ML model supply chain security
+
+  Security Group Detail:
+
+    UUID:        xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Name:        Default LOCAL Group
+    Description: Default security group for LOCAL source type
+    Source Type: LOCAL
+    State:       ACTIVE
+    Created:     2025-08-15T10:30:00.000Z
+    Updated:     2025-08-15T10:30:00.000Z
+```
+
+### Create a group
+
+Create a JSON configuration file:
+
+```json title="group-config.json"
+{
+  "name": "Custom S3 Group",
+  "source_type": "S3",
+  "description": "Custom security group for S3 model sources"
+}
+```
+
+```bash
+daystrom model-security groups create --config group-config.json
+```
+
+### Update a group
+
+```bash
+daystrom model-security groups update <uuid> --name "Renamed Group"
+daystrom model-security groups update <uuid> --description "Updated description"
+```
+
+### Delete a group
+
+```bash
+daystrom model-security groups delete <uuid>
+```
+
+---
+
+## Security Rules
+
+Rules define the security checks applied to models. They are read-only — managed by Prisma AIRS.
+
+### List rules
+
+```bash
+daystrom model-security rules list --limit 5
+```
+
+```
+  Prisma AIRS — Model Security
+  ML model supply chain security
+
+  Security Rules:
+
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Unsafe Deserialization  type: SECURITY  default: BLOCKING
+    Detects model files using unsafe serialization formats
+    Sources: LOCAL, S3, GCS, AZURE, HUGGING_FACE
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Malicious Code Injection  type: SECURITY  default: BLOCKING
+    Scans for embedded malicious code in model artifacts
+    Sources: LOCAL, S3, GCS, AZURE, HUGGING_FACE
+```
+
+### Filter rules
+
+```bash
+# By source type
+daystrom model-security rules list --source-type LOCAL
+
+# Search by name
+daystrom model-security rules list --search "deserialization"
+```
+
+### Get rule details
+
+```bash
+daystrom model-security rules get <uuid>
+```
+
+Shows full rule detail including description, compatible sources, remediation steps, and editable fields.
+
+---
+
+## Rule Instances
+
+Rule instances are the per-group configuration of security rules. Each group has instances for the rules applicable to its source type.
+
+### List rule instances
+
+```bash
+daystrom model-security rule-instances list <groupUuid>
+```
+
+```
+  Prisma AIRS — Model Security
+  ML model supply chain security
+
+  Rule Instances:
+
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Unsafe Deserialization  BLOCKING
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Malicious Code Injection  BLOCKING
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    License Compliance  ALLOWING
+```
+
+### Filter rule instances
+
+```bash
+# By state
+daystrom model-security rule-instances list <groupUuid> --state BLOCKING
+
+# By security rule
+daystrom model-security rule-instances list <groupUuid> --security-rule-uuid <ruleUuid>
+```
+
+### Get rule instance details
+
+```bash
+daystrom model-security rule-instances get <groupUuid> <instanceUuid>
+```
+
+### Update a rule instance
+
+Create a JSON configuration file:
+
+```json title="rule-instance-update.json"
+{
+  "state": "BLOCKING",
+  "field_values": {
+    "threshold": 0.9
+  }
+}
+```
+
+```bash
+daystrom model-security rule-instances update <groupUuid> <instanceUuid> --config rule-instance-update.json
+```
+
+---
+
+## Common Workflows
+
+### Audit a model source
+
+1. List available groups to find the right source type:
+   ```bash
+   daystrom model-security groups list --source-types S3
+   ```
+
+2. Check which rules are active:
+   ```bash
+   daystrom model-security rule-instances list <groupUuid> --state BLOCKING
+   ```
+
+3. Review a specific rule's remediation steps:
+   ```bash
+   daystrom model-security rules get <ruleUuid>
+   ```
+
+### Customize rule enforcement
+
+1. List rule instances in a group:
+   ```bash
+   daystrom model-security rule-instances list <groupUuid>
+   ```
+
+2. Change a rule from ALLOWING to BLOCKING:
+   ```bash
+   echo '{"state": "BLOCKING"}' > update.json
+   daystrom model-security rule-instances update <groupUuid> <instanceUuid> --config update.json
+   ```

--- a/docs/features/model-security.md
+++ b/docs/features/model-security.md
@@ -1,0 +1,70 @@
+# Model Security
+
+Daystrom integrates with Palo Alto Prisma AIRS AI Model Security to manage ML model supply chain security. This enables scanning model artifacts for vulnerabilities, malicious code, and compliance issues before deployment.
+
+## Overview
+
+The `daystrom model-security` command group provides access to Model Security operations:
+
+- **Groups** — manage security groups that define scanning policies per source type
+- **Rules** — browse available security rules (read-only, managed by AIRS)
+- **Rule Instances** — configure rule enforcement within groups (BLOCKING, ALLOWING, DISABLED)
+
+## Concepts
+
+### Security Groups
+
+A security group ties a **source type** (LOCAL, S3, GCS, AZURE, HUGGING_FACE) to a set of **rule instances**. Each group defines the security policy applied when scanning models from that source.
+
+### Security Rules
+
+Rules are the individual checks AIRS performs — unsafe deserialization detection, malicious code injection scanning, license compliance, etc. Rules are managed by AIRS and cannot be created or deleted via the API.
+
+### Rule Instances
+
+When a group is created, AIRS automatically provisions rule instances for all compatible rules. Each instance can be configured independently:
+
+| State | Behavior |
+|-------|----------|
+| `BLOCKING` | Scan fails if rule triggers |
+| `ALLOWING` | Rule evaluates but doesn't block |
+| `DISABLED` | Rule is skipped entirely |
+
+## Workflow
+
+### 1. List available groups
+
+```bash
+daystrom model-security groups list
+```
+
+### 2. Browse security rules
+
+```bash
+daystrom model-security rules list
+daystrom model-security rules get <uuid>
+```
+
+### 3. Configure rule enforcement
+
+```bash
+# View current rule instances in a group
+daystrom model-security rule-instances list <groupUuid>
+
+# Update a rule instance state
+echo '{"state": "BLOCKING"}' > update.json
+daystrom model-security rule-instances update <groupUuid> <instanceUuid> --config update.json
+```
+
+### 4. Create custom groups
+
+```bash
+echo '{"name": "Strict S3 Policy", "source_type": "S3"}' > group.json
+daystrom model-security groups create --config group.json
+```
+
+## CLI Reference
+
+See [CLI Commands — model-security](../reference/cli-commands.md#model-security) for full option details.
+
+See [Model Security Examples](../examples/model-security.md) for hands-on walkthroughs.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -2,7 +2,7 @@
 
 Binary: `daystrom` (or `pnpm run dev` during development).
 
-Six command groups manage the full guardrail lifecycle.
+Seven command groups manage the full guardrail lifecycle.
 
 ---
 
@@ -341,3 +341,80 @@ Abort a running scan.
 ```bash
 daystrom redteam abort <jobId>
 ```
+
+---
+
+## model-security
+
+AI Model Security operations — manage security groups, browse rules, and configure rule instances.
+
+### model-security groups
+
+Manage security groups that define scanning policies for ML model sources.
+
+```bash
+daystrom model-security groups list [options]
+daystrom model-security groups get <uuid>
+daystrom model-security groups create --config <path>
+daystrom model-security groups update <uuid> [options]
+daystrom model-security groups delete <uuid>
+```
+
+| Subcommand | Flags |
+|------------|-------|
+| `list` | `--source-types <types>`, `--search <query>`, `--sort-field <field>`, `--sort-dir <dir>`, `--enabled-rules <uuids>`, `--limit <n>` (default 20) |
+| `get <uuid>` | — |
+| `create` | `--config <path>` (required) |
+| `update <uuid>` | `--name <name>`, `--description <desc>` |
+| `delete <uuid>` | — |
+
+#### Group config JSON format
+
+```json
+{
+  "name": "My Security Group",
+  "source_type": "LOCAL",
+  "description": "Scans local model files",
+  "rule_configurations": {}
+}
+```
+
+### model-security rules
+
+Browse available security rules (read-only).
+
+```bash
+daystrom model-security rules list [options]
+daystrom model-security rules get <uuid>
+```
+
+| Subcommand | Flags |
+|------------|-------|
+| `list` | `--source-type <type>`, `--search <query>`, `--limit <n>` (default 20) |
+| `get <uuid>` | — |
+
+### model-security rule-instances
+
+Manage rule instances within security groups.
+
+```bash
+daystrom model-security rule-instances list <groupUuid> [options]
+daystrom model-security rule-instances get <groupUuid> <instanceUuid>
+daystrom model-security rule-instances update <groupUuid> <instanceUuid> --config <path>
+```
+
+| Subcommand | Flags |
+|------------|-------|
+| `list <groupUuid>` | `--security-rule-uuid <uuid>`, `--state <state>`, `--limit <n>` (default 20) |
+| `get <groupUuid> <instanceUuid>` | — |
+| `update <groupUuid> <instanceUuid>` | `--config <path>` (required) |
+
+#### Rule instance update JSON format
+
+```json
+{
+  "state": "BLOCKING",
+  "field_values": {
+    "threshold": 0.8
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Daystrom
 site_url: https://cdot65.github.io/daystrom/
-site_description: Automated Prisma AIRS custom topic guardrail generator with iterative, self-improving refinement
+site_description: CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning
 repo_name: cdot65/daystrom
 repo_url: https://github.com/cdot65/daystrom
 
@@ -88,6 +88,7 @@ nav:
       - Topic Constraints: features/topic-constraints.md
       - Resumable Runs: features/resumable-runs.md
       - Red Team Scanning: features/red-team.md
+      - Model Security: features/model-security.md
   - Reference:
       - CLI Commands: reference/cli-commands.md
       - Configuration Options: reference/configuration.md
@@ -98,6 +99,7 @@ nav:
       - Managing Targets: examples/managing-targets.md
       - Managing Prompt Sets: examples/managing-prompt-sets.md
       - Running Scans: examples/running-scans.md
+      - Model Security: examples/model-security.md
   - Development:
       - Contributing: development/contributing.md
       - Testing: development/testing.md

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
   "version": "1.7.1",
-  "description": "Automated Prisma AIRS custom topic guardrail generator with iterative refinement",
+  "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cli/commands/modelsecurity.ts
+++ b/src/cli/commands/modelsecurity.ts
@@ -1,0 +1,248 @@
+import * as fs from 'node:fs';
+import type { Command } from 'commander';
+import { SdkModelSecurityService } from '../../airs/modelsecurity.js';
+import { loadConfig } from '../../config/loader.js';
+import {
+  renderError,
+  renderGroupDetail,
+  renderGroupList,
+  renderModelSecurityHeader,
+  renderRuleDetail,
+  renderRuleInstanceDetail,
+  renderRuleInstanceList,
+  renderRuleList,
+} from '../renderer.js';
+
+/** Create an SdkModelSecurityService from config. */
+async function createService() {
+  const config = await loadConfig();
+  return new SdkModelSecurityService({
+    clientId: config.mgmtClientId,
+    clientSecret: config.mgmtClientSecret,
+    tsgId: config.mgmtTsgId,
+    tokenEndpoint: config.mgmtTokenEndpoint,
+  });
+}
+
+/** Register the `model-security` command group. */
+export function registerModelSecurityCommand(program: Command): void {
+  const ms = program
+    .command('model-security')
+    .description('AI Model Security operations — groups, rules, scans');
+
+  // -----------------------------------------------------------------------
+  // model-security groups — security group CRUD
+  // -----------------------------------------------------------------------
+  const groups = ms.command('groups').description('Manage security groups');
+
+  groups
+    .command('list')
+    .description('List security groups')
+    .option('--source-types <types>', 'Filter by source types (comma-separated)')
+    .option('--search <query>', 'Search by name or UUID')
+    .option('--sort-field <field>', 'Sort field (created_at, updated_at)')
+    .option('--sort-dir <dir>', 'Sort direction (asc, desc)')
+    .option('--enabled-rules <uuids>', 'Filter by enabled rule UUIDs (comma-separated)')
+    .option('--limit <n>', 'Max results', '20')
+    .action(async (opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const result = await service.listGroups({
+          sourceTypes: opts.sourceTypes
+            ? (opts.sourceTypes as string).split(',').map((s: string) => s.trim())
+            : undefined,
+          searchQuery: opts.search,
+          sortField: opts.sortField,
+          sortDir: opts.sortDir,
+          enabledRules: opts.enabledRules
+            ? (opts.enabledRules as string).split(',').map((s: string) => s.trim())
+            : undefined,
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderGroupList(result.groups);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  groups
+    .command('get <uuid>')
+    .description('Get security group details')
+    .action(async (uuid: string) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const group = await service.getGroup(uuid);
+        renderGroupDetail(group);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  groups
+    .command('create')
+    .description('Create a security group')
+    .requiredOption('--config <path>', 'JSON file with group configuration')
+    .action(async (opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const group = await service.createGroup({
+          name: config.name,
+          sourceType: config.source_type,
+          description: config.description,
+          ruleConfigurations: config.rule_configurations,
+        });
+        console.log(`  Group created: ${group.uuid}\n`);
+        renderGroupDetail(group);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  groups
+    .command('update <uuid>')
+    .description('Update a security group')
+    .option('--name <name>', 'New name')
+    .option('--description <desc>', 'New description')
+    .action(async (uuid: string, opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const request: { name?: string; description?: string } = {};
+        if (opts.name) request.name = opts.name;
+        if (opts.description) request.description = opts.description;
+        const group = await service.updateGroup(uuid, request);
+        console.log(`  Group updated: ${group.uuid}\n`);
+        renderGroupDetail(group);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  groups
+    .command('delete <uuid>')
+    .description('Delete a security group')
+    .action(async (uuid: string) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        await service.deleteGroup(uuid);
+        console.log(`  Group ${uuid} deleted.\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // model-security rules — browse security rules (read-only)
+  // -----------------------------------------------------------------------
+  const rules = ms.command('rules').description('Browse security rules');
+
+  rules
+    .command('list')
+    .description('List available security rules')
+    .option('--source-type <type>', 'Filter by source type')
+    .option('--search <query>', 'Search by name or UUID')
+    .option('--limit <n>', 'Max results', '20')
+    .action(async (opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const result = await service.listRules({
+          sourceType: opts.sourceType,
+          searchQuery: opts.search,
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderRuleList(result.rules);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  rules
+    .command('get <uuid>')
+    .description('Get security rule details')
+    .action(async (uuid: string) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const rule = await service.getRule(uuid);
+        renderRuleDetail(rule);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // model-security rule-instances — manage rule instances within groups
+  // -----------------------------------------------------------------------
+  const ruleInstances = ms.command('rule-instances').description('Manage rule instances in groups');
+
+  ruleInstances
+    .command('list <groupUuid>')
+    .description('List rule instances in a security group')
+    .option('--security-rule-uuid <uuid>', 'Filter by security rule UUID')
+    .option('--state <state>', 'Filter by state (DISABLED, ALLOWING, BLOCKING)')
+    .option('--limit <n>', 'Max results', '20')
+    .action(async (groupUuid: string, opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const result = await service.listRuleInstances(groupUuid, {
+          securityRuleUuid: opts.securityRuleUuid,
+          state: opts.state,
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderRuleInstanceList(result.ruleInstances);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  ruleInstances
+    .command('get <groupUuid> <instanceUuid>')
+    .description('Get rule instance details')
+    .action(async (groupUuid: string, instanceUuid: string) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const instance = await service.getRuleInstance(groupUuid, instanceUuid);
+        renderRuleInstanceDetail(instance);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  ruleInstances
+    .command('update <groupUuid> <instanceUuid>')
+    .description('Update a rule instance')
+    .requiredOption('--config <path>', 'JSON file with rule instance updates')
+    .action(async (groupUuid: string, instanceUuid: string, opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const instance = await service.updateRuleInstance(groupUuid, instanceUuid, {
+          state: config.state,
+          fieldValues: config.field_values,
+        });
+        console.log(`  Rule instance updated: ${instance.uuid}\n`);
+        renderRuleInstanceDetail(instance);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { registerAuditCommand } from './commands/audit.js';
 import { registerGenerateCommand } from './commands/generate.js';
 import { registerListCommand } from './commands/list.js';
+import { registerModelSecurityCommand } from './commands/modelsecurity.js';
 import { registerRedteamCommand } from './commands/redteam.js';
 import { registerReportCommand } from './commands/report.js';
 import { registerResumeCommand } from './commands/resume.js';
@@ -21,6 +22,7 @@ registerResumeCommand(program);
 registerReportCommand(program);
 registerListCommand(program);
 registerRedteamCommand(program);
+registerModelSecurityCommand(program);
 registerAuditCommand(program);
 
 program.parse();

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -1,4 +1,9 @@
 import chalk from 'chalk';
+import type {
+  ModelSecurityGroup,
+  ModelSecurityRule,
+  ModelSecurityRuleInstance,
+} from '../airs/types.js';
 import type { AuditResult, ConflictPair, ProfileTopic } from '../audit/types.js';
 import type {
   AnalysisReport,
@@ -690,6 +695,141 @@ export function renderConflicts(conflicts: ConflictPair[]): void {
     }
     if (c.evidence.length > 3) {
       console.log(chalk.dim(`    ...and ${c.evidence.length - 3} more`));
+    }
+  }
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Model Security rendering
+// ---------------------------------------------------------------------------
+
+/** Render the model security banner. */
+export function renderModelSecurityHeader(): void {
+  console.log(chalk.bold.blue('\n  Prisma AIRS — Model Security'));
+  console.log(chalk.dim('  ML model supply chain security\n'));
+}
+
+/** Render security group list. */
+export function renderGroupList(groups: ModelSecurityGroup[]): void {
+  if (groups.length === 0) {
+    console.log(chalk.dim('  No security groups found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Security Groups:\n'));
+  for (const g of groups) {
+    console.log(`  ${chalk.dim(g.uuid)}`);
+    const stateColor = g.state === 'ACTIVE' ? chalk.green : chalk.yellow;
+    console.log(`    ${g.name}  ${stateColor(g.state)}  source: ${chalk.dim(g.sourceType)}`);
+  }
+  console.log();
+}
+
+/** Render security group detail. */
+export function renderGroupDetail(group: ModelSecurityGroup): void {
+  console.log(chalk.bold('\n  Security Group Detail:\n'));
+  console.log(`    UUID:        ${chalk.dim(group.uuid)}`);
+  console.log(`    Name:        ${group.name}`);
+  console.log(`    Description: ${group.description || chalk.dim('(none)')}`);
+  console.log(`    Source Type: ${group.sourceType}`);
+  const stateColor = group.state === 'ACTIVE' ? chalk.green : chalk.yellow;
+  console.log(`    State:       ${stateColor(group.state)}`);
+  console.log(`    Created:     ${chalk.dim(group.createdAt)}`);
+  console.log(`    Updated:     ${chalk.dim(group.updatedAt)}`);
+  console.log();
+}
+
+/** Render security rule list. */
+export function renderRuleList(rules: ModelSecurityRule[]): void {
+  if (rules.length === 0) {
+    console.log(chalk.dim('  No security rules found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Security Rules:\n'));
+  for (const r of rules) {
+    console.log(`  ${chalk.dim(r.uuid)}`);
+    console.log(
+      `    ${r.name}  type: ${chalk.dim(r.ruleType)}  default: ${chalk.dim(r.defaultState)}`,
+    );
+    console.log(`    ${chalk.dim(r.description)}`);
+    console.log(`    Sources: ${r.compatibleSources.map((s) => chalk.dim(s)).join(', ')}`);
+  }
+  console.log();
+}
+
+/** Render security rule detail. */
+export function renderRuleDetail(rule: ModelSecurityRule): void {
+  console.log(chalk.bold('\n  Security Rule Detail:\n'));
+  console.log(`    UUID:          ${chalk.dim(rule.uuid)}`);
+  console.log(`    Name:          ${rule.name}`);
+  console.log(`    Description:   ${rule.description}`);
+  console.log(`    Rule Type:     ${rule.ruleType}`);
+  console.log(`    Default State: ${rule.defaultState}`);
+  console.log(`    Sources:       ${rule.compatibleSources.join(', ')}`);
+
+  if (rule.remediation.description) {
+    console.log(chalk.bold('\n    Remediation:'));
+    console.log(`      ${rule.remediation.description}`);
+    if (rule.remediation.steps.length > 0) {
+      for (const step of rule.remediation.steps) {
+        console.log(`      ${chalk.dim('•')} ${step}`);
+      }
+    }
+    if (rule.remediation.url) {
+      console.log(`      ${chalk.dim(rule.remediation.url)}`);
+    }
+  }
+
+  if (rule.editableFields.length > 0) {
+    console.log(chalk.bold('\n    Editable Fields:'));
+    for (const f of rule.editableFields) {
+      console.log(`      ${f.displayName} (${chalk.dim(f.attributeName)}): ${f.displayType}`);
+      if (f.description) console.log(`        ${chalk.dim(f.description)}`);
+    }
+  }
+  console.log();
+}
+
+/** Render rule instance list. */
+export function renderRuleInstanceList(instances: ModelSecurityRuleInstance[]): void {
+  if (instances.length === 0) {
+    console.log(chalk.dim('  No rule instances found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Rule Instances:\n'));
+  for (const ri of instances) {
+    const stateColor =
+      ri.state === 'BLOCKING' ? chalk.red : ri.state === 'ALLOWING' ? chalk.green : chalk.dim;
+    const ruleName = (ri.rule as { name?: string })?.name ?? ri.securityRuleUuid;
+    console.log(`  ${chalk.dim(ri.uuid)}`);
+    console.log(`    ${ruleName}  ${stateColor(ri.state)}`);
+  }
+  console.log();
+}
+
+/** Render rule instance detail. */
+export function renderRuleInstanceDetail(instance: ModelSecurityRuleInstance): void {
+  console.log(chalk.bold('\n  Rule Instance Detail:\n'));
+  console.log(`    UUID:         ${chalk.dim(instance.uuid)}`);
+  console.log(`    Group UUID:   ${chalk.dim(instance.securityGroupUuid)}`);
+  console.log(`    Rule UUID:    ${chalk.dim(instance.securityRuleUuid)}`);
+  const stateColor =
+    instance.state === 'BLOCKING'
+      ? chalk.red
+      : instance.state === 'ALLOWING'
+        ? chalk.green
+        : chalk.dim;
+  console.log(`    State:        ${stateColor(instance.state)}`);
+  const ruleName = (instance.rule as { name?: string })?.name;
+  if (ruleName) console.log(`    Rule Name:    ${ruleName}`);
+  console.log(`    Created:      ${chalk.dim(instance.createdAt)}`);
+  console.log(`    Updated:      ${chalk.dim(instance.updatedAt)}`);
+
+  if (Object.keys(instance.fieldValues).length > 0) {
+    console.log(chalk.bold('\n    Field Values:'));
+    for (const [key, value] of Object.entries(instance.fieldValues)) {
+      const display = Array.isArray(value) ? value.join(', ') : String(value);
+      console.log(`      ${key}: ${chalk.dim(display)}`);
     }
   }
   console.log();


### PR DESCRIPTION
## Summary
- Add `model-security` command group with `groups` (list/get/create/update/delete), `rules` (list/get), `rule-instances` (list/get/update) subcommands
- Add 8 render functions for model security terminal output
- Add docs: features page, examples page, CLI reference section
- Update mkdocs nav and site description

Closes #54, closes #55

## Test plan
- [x] All 390 unit tests pass
- [x] TypeScript compiles cleanly
- [x] Biome lint/format pass
- [ ] Verify groups list/get against live AIRS
- [ ] Verify rules list/get against live AIRS
- [ ] Verify rule-instances list/get against live AIRS

🤖 Generated with [Claude Code](https://claude.com/claude-code)