### PR TITLE
feat: model security scans, labels, pypi-auth CLI

### DIFF
--- a/docs/examples/model-security.md
+++ b/docs/examples/model-security.md
@@ -200,6 +200,126 @@ daystrom model-security rule-instances update <groupUuid> <instanceUuid> --confi
 
 ---
 
+## Scans
+
+### List scans
+
+```bash
+daystrom model-security scans list
+```
+
+```
+  Prisma AIRS — Model Security
+  ML model supply chain security
+
+  Model Security Scans:
+
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    COMPLETED  2025-09-01T14:30:00.000Z
+    Rules: 8 passed  2 failed  / 10 total
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    COMPLETED  2025-09-02T10:00:00.000Z
+    Rules: 10 passed  0 failed  / 10 total
+```
+
+### Filter scans
+
+```bash
+# By evaluation outcome
+daystrom model-security scans list --eval-outcome FAILED
+
+# By source type
+daystrom model-security scans list --source-type LOCAL
+
+# Search
+daystrom model-security scans list --search "model-name"
+```
+
+### Get scan details
+
+```bash
+daystrom model-security scans get <uuid>
+```
+
+### View scan evaluations
+
+```bash
+daystrom model-security scans evaluations <scanUuid>
+```
+
+```
+  Prisma AIRS — Model Security
+  ML model supply chain security
+
+  Rule Evaluations:
+
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Unsafe Deserialization  ALLOWED
+  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    Malicious Code Injection  BLOCKED
+```
+
+### View violations
+
+```bash
+daystrom model-security scans violations <scanUuid>
+```
+
+### View scanned files
+
+```bash
+daystrom model-security scans files <scanUuid>
+
+# Filter by result
+daystrom model-security scans files <scanUuid> --result FAILED
+```
+
+---
+
+## Labels
+
+Labels help organize and categorize scans.
+
+### Add labels
+
+```bash
+daystrom model-security labels add <scanUuid> --labels '[{"key":"env","value":"prod"}]'
+```
+
+### Set labels (replace all)
+
+```bash
+daystrom model-security labels set <scanUuid> --labels '[{"key":"env","value":"staging"},{"key":"team","value":"ml"}]'
+```
+
+### Delete labels
+
+```bash
+daystrom model-security labels delete <scanUuid> --keys env,team
+```
+
+### Browse label taxonomy
+
+```bash
+# List all label keys
+daystrom model-security labels keys
+
+# List values for a key
+daystrom model-security labels values env
+```
+
+---
+
+## PyPI Authentication
+
+Get authentication URL for Google Artifact Registry (used for model scanning tools).
+
+```bash
+daystrom model-security pypi-auth
+```
+
+---
+
 ## Common Workflows
 
 ### Audit a model source

--- a/docs/features/model-security.md
+++ b/docs/features/model-security.md
@@ -9,6 +9,9 @@ The `daystrom model-security` command group provides access to Model Security op
 - **Groups** — manage security groups that define scanning policies per source type
 - **Rules** — browse available security rules (read-only, managed by AIRS)
 - **Rule Instances** — configure rule enforcement within groups (BLOCKING, ALLOWING, DISABLED)
+- **Scans** — create, list, and inspect model security scans with evaluations, violations, and file results
+- **Labels** — organize scans with key-value labels
+- **PyPI Auth** — get authentication for Google Artifact Registry
 
 ## Concepts
 
@@ -61,6 +64,29 @@ daystrom model-security rule-instances update <groupUuid> <instanceUuid> --confi
 ```bash
 echo '{"name": "Strict S3 Policy", "source_type": "S3"}' > group.json
 daystrom model-security groups create --config group.json
+```
+
+### 5. Inspect scan results
+
+```bash
+# List scans
+daystrom model-security scans list
+
+# View evaluations for a scan
+daystrom model-security scans evaluations <scanUuid>
+
+# View violations
+daystrom model-security scans violations <scanUuid>
+
+# View scanned files
+daystrom model-security scans files <scanUuid>
+```
+
+### 6. Organize with labels
+
+```bash
+daystrom model-security labels add <scanUuid> --labels '[{"key":"env","value":"prod"}]'
+daystrom model-security labels keys
 ```
 
 ## CLI Reference

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -418,3 +418,57 @@ daystrom model-security rule-instances update <groupUuid> <instanceUuid> --confi
     "threshold": 0.8
   }
 }
+```
+
+### model-security scans
+
+Model security scan operations — create, list, inspect scans and their results.
+
+```bash
+daystrom model-security scans list [options]
+daystrom model-security scans get <uuid>
+daystrom model-security scans create --config <path>
+daystrom model-security scans evaluations <scanUuid> [--limit <n>]
+daystrom model-security scans evaluation <uuid>
+daystrom model-security scans violations <scanUuid> [--limit <n>]
+daystrom model-security scans violation <uuid>
+daystrom model-security scans files <scanUuid> [--type <type>] [--result <result>] [--limit <n>]
+```
+
+| Subcommand | Flags |
+|------------|-------|
+| `list` | `--eval-outcome <outcome>`, `--source-type <type>`, `--scan-origin <origin>`, `--search <query>`, `--limit <n>` (default 20) |
+| `get <uuid>` | — |
+| `create` | `--config <path>` (required) |
+| `evaluations <scanUuid>` | `--limit <n>` (default 20) |
+| `evaluation <uuid>` | — |
+| `violations <scanUuid>` | `--limit <n>` (default 20) |
+| `violation <uuid>` | — |
+| `files <scanUuid>` | `--type <type>`, `--result <result>`, `--limit <n>` (default 20) |
+
+### model-security labels
+
+Manage labels on model security scans.
+
+```bash
+daystrom model-security labels add <scanUuid> --labels '<json>'
+daystrom model-security labels set <scanUuid> --labels '<json>'
+daystrom model-security labels delete <scanUuid> --keys <key1,key2>
+daystrom model-security labels keys [--limit <n>]
+daystrom model-security labels values <key> [--limit <n>]
+```
+
+| Subcommand | Flags |
+|------------|-------|
+| `add <scanUuid>` | `--labels <json>` (required) |
+| `set <scanUuid>` | `--labels <json>` (required) |
+| `delete <scanUuid>` | `--keys <keys>` (required, comma-separated) |
+| `keys` | `--limit <n>` (default 20) |
+| `values <key>` | `--limit <n>` (default 20) |
+
+### model-security pypi-auth
+
+Get PyPI authentication URL for Google Artifact Registry.
+
+```bash
+daystrom model-security pypi-auth

--- a/src/cli/commands/modelsecurity.ts
+++ b/src/cli/commands/modelsecurity.ts
@@ -1,16 +1,26 @@
 import * as fs from 'node:fs';
+import chalk from 'chalk';
 import type { Command } from 'commander';
 import { SdkModelSecurityService } from '../../airs/modelsecurity.js';
 import { loadConfig } from '../../config/loader.js';
 import {
   renderError,
+  renderEvaluationDetail,
+  renderEvaluationList,
+  renderFileList,
   renderGroupDetail,
   renderGroupList,
+  renderLabelKeys,
+  renderLabelValues,
   renderModelSecurityHeader,
+  renderMsScanDetail,
+  renderMsScanList,
   renderRuleDetail,
   renderRuleInstanceDetail,
   renderRuleInstanceList,
   renderRuleList,
+  renderViolationDetail,
+  renderViolationList,
 } from '../renderer.js';
 
 /** Create an SdkModelSecurityService from config. */
@@ -240,6 +250,270 @@ export function registerModelSecurityCommand(program: Command): void {
         });
         console.log(`  Rule instance updated: ${instance.uuid}\n`);
         renderRuleInstanceDetail(instance);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // model-security scans — scan operations + results
+  // -----------------------------------------------------------------------
+  const scans = ms.command('scans').description('Model security scan operations');
+
+  scans
+    .command('list')
+    .description('List model security scans')
+    .option('--eval-outcome <outcome>', 'Filter by eval outcome')
+    .option('--source-type <type>', 'Filter by source type')
+    .option('--scan-origin <origin>', 'Filter by scan origin')
+    .option('--search <query>', 'Search scans')
+    .option('--limit <n>', 'Max results', '20')
+    .action(async (opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const result = await service.listScans({
+          evalOutcome: opts.evalOutcome,
+          sourceType: opts.sourceType,
+          scanOrigin: opts.scanOrigin,
+          search: opts.search,
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderMsScanList(result.scans);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  scans
+    .command('get <uuid>')
+    .description('Get scan details')
+    .action(async (uuid: string) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const scan = await service.getScan(uuid);
+        renderMsScanDetail(scan);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  scans
+    .command('create')
+    .description('Create a model security scan')
+    .requiredOption('--config <path>', 'JSON file with scan configuration')
+    .action(async (opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const scan = await service.createScan(config);
+        console.log(`  Scan created: ${scan.uuid}\n`);
+        renderMsScanDetail(scan);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  scans
+    .command('evaluations <scanUuid>')
+    .description('List rule evaluations for a scan')
+    .option('--limit <n>', 'Max results', '20')
+    .action(async (scanUuid: string, opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const result = await service.getEvaluations(scanUuid, {
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderEvaluationList(result.evaluations);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  scans
+    .command('evaluation <uuid>')
+    .description('Get evaluation details')
+    .action(async (uuid: string) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const evaluation = await service.getEvaluation(uuid);
+        renderEvaluationDetail(evaluation);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  scans
+    .command('violations <scanUuid>')
+    .description('List violations for a scan')
+    .option('--limit <n>', 'Max results', '20')
+    .action(async (scanUuid: string, opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const result = await service.getViolations(scanUuid, {
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderViolationList(result.violations);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  scans
+    .command('violation <uuid>')
+    .description('Get violation details')
+    .action(async (uuid: string) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const violation = await service.getViolation(uuid);
+        renderViolationDetail(violation);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  scans
+    .command('files <scanUuid>')
+    .description('List scanned files')
+    .option('--type <type>', 'Filter by file type')
+    .option('--result <result>', 'Filter by result')
+    .option('--limit <n>', 'Max results', '20')
+    .action(async (scanUuid: string, opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const result = await service.getFiles(scanUuid, {
+          type: opts.type,
+          result: opts.result,
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderFileList(result.files);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // model-security labels — scan label management
+  // -----------------------------------------------------------------------
+  const labels = ms.command('labels').description('Manage scan labels');
+
+  labels
+    .command('add <scanUuid>')
+    .description('Add labels to a scan')
+    .requiredOption('--labels <json>', 'JSON array of {key, value} labels')
+    .action(async (scanUuid: string, opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const parsed = JSON.parse(opts.labels);
+        await service.addLabels(scanUuid, parsed);
+        console.log('  Labels added.\n');
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  labels
+    .command('set <scanUuid>')
+    .description('Replace all labels on a scan')
+    .requiredOption('--labels <json>', 'JSON array of {key, value} labels')
+    .action(async (scanUuid: string, opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const parsed = JSON.parse(opts.labels);
+        await service.setLabels(scanUuid, parsed);
+        console.log('  Labels set.\n');
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  labels
+    .command('delete <scanUuid>')
+    .description('Delete labels from a scan by key')
+    .requiredOption('--keys <keys>', 'Comma-separated label keys to delete')
+    .action(async (scanUuid: string, opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const keys = (opts.keys as string).split(',').map((k: string) => k.trim());
+        await service.deleteLabels(scanUuid, keys);
+        console.log('  Labels deleted.\n');
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  labels
+    .command('keys')
+    .description('List available label keys')
+    .option('--limit <n>', 'Max results', '20')
+    .action(async (opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const result = await service.getLabelKeys({
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderLabelKeys(result.keys);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  labels
+    .command('values <key>')
+    .description('List values for a label key')
+    .option('--limit <n>', 'Max results', '20')
+    .action(async (key: string, opts) => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const result = await service.getLabelValues(key, {
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderLabelValues(key, result.values);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // model-security pypi-auth — PyPI authentication for Google Artifact Registry
+  // -----------------------------------------------------------------------
+  ms.command('pypi-auth')
+    .description('Get PyPI authentication URL for Google Artifact Registry')
+    .action(async () => {
+      try {
+        renderModelSecurityHeader();
+        const service = await createService();
+        const auth = await service.getPyPIAuth();
+        console.log(chalk.bold('\n  PyPI Authentication:\n'));
+        console.log(`    URL:     ${auth.url}`);
+        console.log(`    Expires: ${chalk.dim(auth.expiresAt)}`);
+        console.log();
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -1,8 +1,12 @@
 import chalk from 'chalk';
 import type {
+  ModelSecurityEvaluation,
+  ModelSecurityFile,
   ModelSecurityGroup,
   ModelSecurityRule,
   ModelSecurityRuleInstance,
+  ModelSecurityScan,
+  ModelSecurityViolation,
 } from '../airs/types.js';
 import type { AuditResult, ConflictPair, ProfileTopic } from '../audit/types.js';
 import type {
@@ -831,6 +835,175 @@ export function renderRuleInstanceDetail(instance: ModelSecurityRuleInstance): v
       const display = Array.isArray(value) ? value.join(', ') : String(value);
       console.log(`      ${key}: ${chalk.dim(display)}`);
     }
+  }
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Model Security — Scans
+// ---------------------------------------------------------------------------
+
+/** Render a list of model security scans. */
+export function renderMsScanList(scans: ModelSecurityScan[]): void {
+  if (scans.length === 0) {
+    console.log(chalk.dim('  No scans found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Model Security Scans:\n'));
+  for (const s of scans) {
+    const statusColor =
+      s.status === 'COMPLETED' ? chalk.green : s.status === 'FAILED' ? chalk.red : chalk.yellow;
+    console.log(`  ${chalk.dim(s.uuid)}`);
+    console.log(`    ${statusColor(s.status)}  ${chalk.dim(s.createdAt)}`);
+    if (s.evalSummary) {
+      const { rulesPassed, rulesFailed, totalRules } = s.evalSummary;
+      console.log(
+        `    Rules: ${chalk.green(`${rulesPassed} passed`)}  ${chalk.red(`${rulesFailed} failed`)}  / ${totalRules} total`,
+      );
+    }
+  }
+  console.log();
+}
+
+/** Render full scan detail. */
+export function renderMsScanDetail(scan: ModelSecurityScan): void {
+  console.log(chalk.bold('\n  Scan Detail:\n'));
+  console.log(`    UUID:    ${chalk.dim(scan.uuid)}`);
+  const statusColor =
+    scan.status === 'COMPLETED' ? chalk.green : scan.status === 'FAILED' ? chalk.red : chalk.yellow;
+  console.log(`    Status:  ${statusColor(scan.status)}`);
+  console.log(`    Created: ${chalk.dim(scan.createdAt)}`);
+  console.log(`    Updated: ${chalk.dim(scan.updatedAt)}`);
+  if (scan.evalSummary) {
+    const { rulesPassed, rulesFailed, totalRules } = scan.evalSummary;
+    console.log(
+      `    Rules:   ${chalk.green(`${rulesPassed} passed`)}  ${chalk.red(`${rulesFailed} failed`)}  / ${totalRules} total`,
+    );
+  }
+  if (scan.labels.length > 0) {
+    console.log(chalk.bold('\n    Labels:'));
+    for (const l of scan.labels) {
+      console.log(`      ${l.key}: ${chalk.dim(l.value)}`);
+    }
+  }
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Model Security — Evaluations
+// ---------------------------------------------------------------------------
+
+/** Render a list of evaluations. */
+export function renderEvaluationList(evaluations: ModelSecurityEvaluation[]): void {
+  if (evaluations.length === 0) {
+    console.log(chalk.dim('  No evaluations found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Rule Evaluations:\n'));
+  for (const e of evaluations) {
+    const color =
+      e.evalOutcome === 'ALLOWED'
+        ? chalk.green
+        : e.evalOutcome === 'BLOCKED'
+          ? chalk.red
+          : chalk.yellow;
+    console.log(`  ${chalk.dim(e.uuid)}`);
+    console.log(`    ${e.ruleName}  ${color(e.evalOutcome)}`);
+  }
+  console.log();
+}
+
+/** Render a single evaluation detail. */
+export function renderEvaluationDetail(evaluation: ModelSecurityEvaluation): void {
+  console.log(chalk.bold('\n  Evaluation Detail:\n'));
+  console.log(`    UUID:      ${chalk.dim(evaluation.uuid)}`);
+  console.log(`    Rule:      ${evaluation.ruleName}`);
+  console.log(`    Rule UUID: ${chalk.dim(evaluation.securityRuleUuid)}`);
+  const color =
+    evaluation.evalOutcome === 'ALLOWED'
+      ? chalk.green
+      : evaluation.evalOutcome === 'BLOCKED'
+        ? chalk.red
+        : chalk.yellow;
+  console.log(`    Outcome:   ${color(evaluation.evalOutcome)}`);
+  console.log(`    Result:    ${evaluation.result}`);
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Model Security — Violations
+// ---------------------------------------------------------------------------
+
+/** Render a list of violations. */
+export function renderViolationList(violations: ModelSecurityViolation[]): void {
+  if (violations.length === 0) {
+    console.log(chalk.dim('  No violations found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Violations:\n'));
+  for (const v of violations) {
+    console.log(`  ${chalk.dim(v.uuid)}`);
+    console.log(`    ${chalk.red(v.ruleName)}  ${chalk.dim(v.filePath)}`);
+    console.log(`    ${v.description}`);
+  }
+  console.log();
+}
+
+/** Render a single violation detail. */
+export function renderViolationDetail(violation: ModelSecurityViolation): void {
+  console.log(chalk.bold('\n  Violation Detail:\n'));
+  console.log(`    UUID:        ${chalk.dim(violation.uuid)}`);
+  console.log(`    Rule:        ${chalk.red(violation.ruleName)}`);
+  console.log(`    File:        ${violation.filePath}`);
+  console.log(`    Description: ${violation.description}`);
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Model Security — Files
+// ---------------------------------------------------------------------------
+
+/** Render a list of scanned files. */
+export function renderFileList(files: ModelSecurityFile[]): void {
+  if (files.length === 0) {
+    console.log(chalk.dim('  No files found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Scanned Files:\n'));
+  for (const f of files) {
+    const color =
+      f.result === 'PASSED' ? chalk.green : f.result === 'FAILED' ? chalk.red : chalk.yellow;
+    console.log(`    ${color(f.result)}  ${f.type}  ${chalk.dim(f.filePath)}`);
+  }
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Model Security — Labels
+// ---------------------------------------------------------------------------
+
+/** Render label keys. */
+export function renderLabelKeys(keys: string[]): void {
+  if (keys.length === 0) {
+    console.log(chalk.dim('  No label keys found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Label Keys:\n'));
+  for (const k of keys) {
+    console.log(`    ${k}`);
+  }
+  console.log();
+}
+
+/** Render label values for a key. */
+export function renderLabelValues(key: string, values: string[]): void {
+  if (values.length === 0) {
+    console.log(chalk.dim(`  No values for key "${key}".\n`));
+    return;
+  }
+  console.log(chalk.bold(`\n  Label Values for "${key}":\n`));
+  for (const v of values) {
+    console.log(`    ${v}`);
   }
   console.log();
 }


### PR DESCRIPTION
## Summary
- Add `scans` subcommand group: list/get/create scans, evaluations, violations, files
- Add `labels` subcommand group: add/set/delete labels, browse keys/values
- Add `pypi-auth` command for Google Artifact Registry auth
- Add 10 render functions for scan results
- Update docs: CLI reference, examples page, features page

Closes #56

## Test plan
- [x] All 390 unit tests pass
- [x] TypeScript compiles cleanly
- [x] Biome lint/format pass
- [ ] Verify scans list/get against live AIRS
- [ ] Verify evaluations/violations/files for completed scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)