### PR TITLE
docs: model security cross-references + release notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,15 +41,16 @@ TypeScript ESM, Node 20+, pnpm. LangChain.js w/ structured output (Zod). `@cdot6
 
 ```
 src/
-├── cli/                   # CLI entry, 6 command groups, interactive prompts, renderer
-│   ├── index.ts           # Commander program — registers generate/resume/report/list/audit/redteam
+├── cli/                   # CLI entry, 7 command groups, interactive prompts, renderer
+│   ├── index.ts           # Commander program — registers generate/resume/report/list/audit/redteam/model-security
 │   ├── commands/
 │   │   ├── generate.ts    # Main loop orchestration, wires all services
 │   │   ├── resume.ts      # Resume paused/failed run from disk
 │   │   ├── report.ts      # View run results by ID
 │   │   ├── list.ts        # List all saved runs
 │   │   ├── audit.ts       # Profile-level multi-topic evaluation
-│   │   └── redteam.ts     # Red team operations (scan, targets CRUD, prompt-sets CRUD, prompts CRUD, properties)
+│   │   ├── redteam.ts     # Red team operations (scan, targets CRUD, prompt-sets CRUD, prompts CRUD, properties)
+│   │   └── modelsecurity.ts # Model security operations (groups, rules, rule-instances, scans, labels, pypi-auth)
 │   ├── prompts.ts         # Inquirer interactive input collection
 │   └── renderer.ts        # Terminal output (chalk)
 ├── config/
@@ -70,7 +71,8 @@ src/
 │   ├── management.ts      # SdkManagementService — topic CRUD + profile linking
 │   ├── promptsets.ts      # SdkPromptSetService — custom prompt set CRUD via RedTeamClient
 │   ├── redteam.ts         # SdkRedTeamService — red team scan CRUD, polling, reports
-│   └── types.ts           # ScanResult, ScanService, ManagementService, PromptSetService, RedTeamService
+│   ├── modelsecurity.ts   # SdkModelSecurityService — security groups, rules, scans, labels
+│   └── types.ts           # ScanResult, ScanService, ManagementService, PromptSetService, RedTeamService, ModelSecurityService
 ├── memory/
 │   ├── store.ts           # MemoryStore — file-based persistence, keyword category matching (≥50% overlap)
 │   ├── extractor.ts       # LearningExtractor — post-loop LLM extraction, merge/corroboration
@@ -95,8 +97,8 @@ src/
 └── index.ts               # Library exports
 
 tests/
-├── unit/                  # 22 spec files
-│   ├── airs/              # scanner.spec.ts, management.spec.ts
+├── unit/                  # 23 spec files
+│   ├── airs/              # scanner.spec.ts, management.spec.ts, modelsecurity.spec.ts
 │   ├── audit/             # evaluator.spec.ts, runner.spec.ts, report.spec.ts
 │   ├── config/            # schema.spec.ts, loader.spec.ts
 │   ├── core/              # loop.spec.ts, metrics.spec.ts, constraints.spec.ts
@@ -145,6 +147,14 @@ tests/
 - `waitForCompletion()` polls with configurable interval, throws on FAILED
 - Target create/update accept `{ validate: true }` to validate connection before saving (SDK v0.6.0)
 - CLI subcommand groups: `targets {list,get,create,update,delete,probe,profile,update-profile}`, `prompt-sets {list,get,create,update,archive,download,upload}`, `prompts {list,get,add,update,delete}`, `properties {list,create,values,add-value}`
+
+### Model Security (`src/airs/modelsecurity.ts`)
+- `SdkModelSecurityService` wraps `ModelSecurityClient` for security groups, rules, scans, labels, PyPI auth
+- snake_case (SDK) → camelCase (daystrom) normalization via `normalizeGroup()`, `normalizeRule()`, etc.
+- CLI: `daystrom model-security {groups,rules,rule-instances,scans,labels,pypi-auth}`
+- Groups: CRUD per source type (LOCAL, S3, GCS, AZURE, HUGGING_FACE)
+- Rule instances: state = BLOCKING | ALLOWING | DISABLED
+- Scans: create/list/get with evaluations, violations, files sub-queries
 
 ### LLM Service (`src/llm/`)
 - 6 providers: `claude-api` (default), `claude-vertex`, `claude-bedrock`, `gemini-api`, `gemini-vertex`, `gemini-bedrock`

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## v1.7.2
+
+### Features
+
+- **`daystrom model-security` command group**: Full AI Model Security operations — security groups CRUD, rule browsing, rule instance configuration, scan operations (create/list/get), evaluations, violations, files, label management, and PyPI authentication.
+- **`SdkModelSecurityService`**: New service wrapping `ModelSecurityClient` with camelCase normalization for all 23 SDK methods.
+- **5 subcommand groups**: `groups` (list/get/create/update/delete), `rules` (list/get), `rule-instances` (list/get/update), `scans` (list/get/create/evaluations/violations/files), `labels` (add/set/delete/keys/values), plus `pypi-auth`.
+- **SDK upgrade**: `@cdot65/prisma-airs-sdk` v0.6.0 → v0.6.1 — fixed list filter options for groups, rules, and rule instances.
+
+### Tests
+
+- 390 tests across 25 spec files (up from 360)
+
 ## v1.7.0
 
 ### Features

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -10,7 +10,7 @@ src/
 ├── config/           Zod-validated config schema + cascade loader
 ├── core/             Async generator loop, efficacy metrics, AIRS constraints
 ├── llm/              LangChain provider factory, structured output, prompts
-├── airs/             Scanner, Management (topic CRUD), Red Team (scan CRUD), Prompt Sets
+├── airs/             Scanner, Management (topic CRUD), Red Team, Prompt Sets, Model Security
 ├── memory/           Learning store, extractor, budget-aware injector
 ├── persistence/      JSON file store for run state
 ├── audit/            Profile-level multi-topic evaluation + conflict detection
@@ -48,11 +48,11 @@ graph TD
 
 | Module | What it does |
 |--------|-------------|
-| **`cli/`** | Commander CLI with 6 command groups (`generate`, `resume`, `report`, `list`, `audit`, `redteam`), Inquirer prompts, and Chalk terminal output |
+| **`cli/`** | Commander CLI with 7 command groups (`generate`, `resume`, `report`, `list`, `audit`, `redteam`, `model-security`), Inquirer prompts, and Chalk terminal output |
 | **`config/`** | Zod schema with coercion and defaults; cascade loader merges CLI flags, env vars, config file, and defaults |
 | **`core/`** | AsyncGenerator loop that yields typed events, metric computation (TPR/TNR/F1), and AIRS constraint validation |
 | **`llm/`** | Factory for 6 LangChain providers, structured output with Zod schemas, and prompt templates for all 4 LLM calls |
-| **`airs/`** | Scan API with batched concurrency via `p-limit`, Management API for topic CRUD and profile linking, Red Team service for scan CRUD/polling/reports, Prompt Set service for custom prompt set management |
+| **`airs/`** | Scan API with batched concurrency via `p-limit`, Management API for topic CRUD and profile linking, Red Team service for scan CRUD/polling/reports, Prompt Set service for custom prompt set management, Model Security service for security groups/rules/scans |
 | **`memory/`** | File-based learning store, LLM-driven extraction after each run, and budget-aware injection into future prompts |
 | **`persistence/`** | `JsonFileStore` serializes `RunState` to `~/.daystrom/runs/` for pause/resume support |
 | **`audit/`** | Profile-level multi-topic evaluation — generates tests per topic, computes per-topic and composite metrics, detects cross-topic conflicts |

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,14 @@ Daystrom is a CLI tool that takes a plain-English description of what you want t
 
     Evaluate all topics in a security profile at once. Per-topic metrics, composite scores, and cross-topic conflict detection via `daystrom audit`.
 
+-   :material-shield-lock:{ .lg .middle } **Model Security**
+
+    ---
+
+    Manage ML model supply chain security — security groups, rules, scans, evaluations, violations, and labels via `daystrom model-security`.
+
+    [:octicons-arrow-right-24: Model Security](features/model-security.md)
+
 </div>
 
 ---


### PR DESCRIPTION
## Summary
- Add Model Security feature card to docs home page
- Update architecture overview: module table, command count, airs description
- Add v1.7.2 release notes entry
- Update CLAUDE.md: directory structure, test file count, Model Security architecture section

Closes #57

## Test plan
- [x] All 390 tests pass
- [x] Lint/typecheck clean
- [x] Docs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)