### PR TITLE
fix: align scan/evaluation/violation/file types with live AIRS API

### DIFF
--- a/docs/examples/model-security.md
+++ b/docs/examples/model-security.md
@@ -1,6 +1,8 @@
 # Model Security Operations
 
-This guide walks through managing AI Model Security using the `daystrom model-security` command group — security groups, rules, and rule instances.
+This guide walks through managing AI Model Security using the `daystrom model-security` command group — security groups, rules, rule instances, scans, and labels.
+
+All output shown below is captured from real Prisma AIRS API responses.
 
 ---
 
@@ -18,55 +20,52 @@ daystrom model-security groups list
 
   Security Groups:
 
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Default GCS Group  ACTIVE  source: GCS
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Default LOCAL Group  ACTIVE  source: LOCAL
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Default S3 Group  ACTIVE  source: S3
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Default AZURE Group  ACTIVE  source: AZURE
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Default HUGGING_FACE Group  ACTIVE  source: HUGGING_FACE
+  bb1d038a-0506-4b07-8f16-a723b8c1a1c7
+    Default GCS  ACTIVE  source: GCS
+  020d546d-3920-4ef3-9183-00f37f33f566
+    Default LOCAL  ACTIVE  source: LOCAL
+  6a1e67e1-00cc-45dc-9395-3a9e3dbf50f9
+    Default S3  ACTIVE  source: S3
+  fd1a4209-32d0-4a1a-bd40-cde35104dc39
+    Default AZURE  ACTIVE  source: AZURE
+  4c22aef7-2ab7-40ba-b3f1-cd9e9aa1768e
+    Default HUGGING_FACE  ACTIVE  source: HUGGING_FACE
 ```
 
-### Filter groups
+### Filter groups by source type
 
 ```bash
-# By source type
 daystrom model-security groups list --source-types LOCAL,S3
+```
 
-# Search by name
-daystrom model-security groups list --search "Default"
+```
+  Security Groups:
 
-# Sort by creation date
-daystrom model-security groups list --sort-field created_at --sort-dir desc
+  020d546d-3920-4ef3-9183-00f37f33f566
+    Default LOCAL  ACTIVE  source: LOCAL
+  6a1e67e1-00cc-45dc-9395-3a9e3dbf50f9
+    Default S3  ACTIVE  source: S3
 ```
 
 ### Get group details
 
 ```bash
-daystrom model-security groups get <uuid>
+daystrom model-security groups get bb1d038a-0506-4b07-8f16-a723b8c1a1c7
 ```
 
 ```
-  Prisma AIRS — Model Security
-  ML model supply chain security
-
   Security Group Detail:
 
-    UUID:        xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Name:        Default LOCAL Group
-    Description: Default security group for LOCAL source type
-    Source Type: LOCAL
+    UUID:        bb1d038a-0506-4b07-8f16-a723b8c1a1c7
+    Name:        Default GCS
+    Description: Auto-created default security group for GCS models
+    Source Type: GCS
     State:       ACTIVE
-    Created:     2025-08-15T10:30:00.000Z
-    Updated:     2025-08-15T10:30:00.000Z
+    Created:     2025-10-30T14:14:17.321066Z
+    Updated:     2026-02-19T16:03:26.660748Z
 ```
 
 ### Create a group
-
-Create a JSON configuration file:
 
 ```json title="group-config.json"
 {
@@ -80,16 +79,10 @@ Create a JSON configuration file:
 daystrom model-security groups create --config group-config.json
 ```
 
-### Update a group
+### Update and delete
 
 ```bash
 daystrom model-security groups update <uuid> --name "Renamed Group"
-daystrom model-security groups update <uuid> --description "Updated description"
-```
-
-### Delete a group
-
-```bash
 daystrom model-security groups delete <uuid>
 ```
 
@@ -106,84 +99,143 @@ daystrom model-security rules list --limit 5
 ```
 
 ```
-  Prisma AIRS — Model Security
-  ML model supply chain security
-
   Security Rules:
 
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Unsafe Deserialization  type: SECURITY  default: BLOCKING
-    Detects model files using unsafe serialization formats
-    Sources: LOCAL, S3, GCS, AZURE, HUGGING_FACE
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Malicious Code Injection  type: SECURITY  default: BLOCKING
-    Scans for embedded malicious code in model artifacts
-    Sources: LOCAL, S3, GCS, AZURE, HUGGING_FACE
+  550e8400-e29b-41d4-a716-44665544000b
+    Known Framework Operators Check  type: ARTIFACT  default: BLOCKING
+    Model artifacts should only contain known safe TensorFlow operators
+    Sources: ALL
+  550e8400-e29b-41d4-a716-446655440006
+    License Exists  type: METADATA  default: BLOCKING
+    Models should have a license
+    Sources: HUGGING_FACE
+  550e8400-e29b-41d4-a716-446655440007
+    License Is Valid For Use  type: METADATA  default: BLOCKING
+    Models license should be valid for use
+    Sources: HUGGING_FACE
+  550e8400-e29b-41d4-a716-446655440008
+    Load Time Code Execution Check  type: ARTIFACT  default: BLOCKING
+    Model artifacts should not contain unsafe operators that are run upon deserialization
+    Sources: ALL
+  550e8400-e29b-41d4-a716-44665544000a
+    Model Architecture Backdoor Check  type: ARTIFACT  default: BLOCKING
+    Model architecture files should not contain backdoor attacks
+    Sources: ALL
 ```
 
-### Filter rules
+### Search rules
 
 ```bash
-# By source type
-daystrom model-security rules list --source-type LOCAL
+daystrom model-security rules list --search "License"
+```
 
-# Search by name
-daystrom model-security rules list --search "deserialization"
+```
+  Security Rules:
+
+  550e8400-e29b-41d4-a716-446655440006
+    License Exists  type: METADATA  default: BLOCKING
+    Models should have a license
+    Sources: HUGGING_FACE
+  550e8400-e29b-41d4-a716-446655440007
+    License Is Valid For Use  type: METADATA  default: BLOCKING
+    Models license should be valid for use
+    Sources: HUGGING_FACE
 ```
 
 ### Get rule details
 
 ```bash
-daystrom model-security rules get <uuid>
+daystrom model-security rules get 550e8400-e29b-41d4-a716-44665544000b
 ```
 
-Shows full rule detail including description, compatible sources, remediation steps, and editable fields.
+```
+  Security Rule Detail:
+
+    UUID:          550e8400-e29b-41d4-a716-44665544000b
+    Name:          Known Framework Operators Check
+    Description:   Model artifacts should only contain known safe TensorFlow operators
+    Rule Type:     ARTIFACT
+    Default State: BLOCKING
+    Sources:       ALL
+
+    Remediation:
+      Ensure that the model does not contain any custom TensorFlow operators
+      https://docs.paloaltonetworks.com/.../known-framework-operators-check
+```
 
 ---
 
 ## Rule Instances
 
-Rule instances are the per-group configuration of security rules. Each group has instances for the rules applicable to its source type.
+Rule instances are the per-group configuration of security rules.
 
 ### List rule instances
 
 ```bash
-daystrom model-security rule-instances list <groupUuid>
+daystrom model-security rule-instances list 020d546d-3920-4ef3-9183-00f37f33f566
 ```
 
 ```
-  Prisma AIRS — Model Security
-  ML model supply chain security
-
   Rule Instances:
 
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Unsafe Deserialization  BLOCKING
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Malicious Code Injection  BLOCKING
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    License Compliance  ALLOWING
+  67185c67-020a-4625-816f-9a2137e3d6b3
+    Known Framework Operators Check  BLOCKING
+  34f0a130-d2a3-451d-8795-776f5d5bdd8f
+    Load Time Code Execution Check  BLOCKING
+  0fe19730-3fb4-474b-9160-d2de02be592b
+    Model Architecture Backdoor Check  BLOCKING
+  c532d04b-ca2d-4e03-8b4b-8a81917c02cf
+    Runtime Code Execution Check  BLOCKING
+  53aab919-06c4-4ebf-a1e1-8124ce2ae0d5
+    Stored In Approved File Format  BLOCKING
+  6648097a-37bd-4726-ab51-a63188c52a23
+    Stored In Approved Location  DISABLED
+  43dd1d74-f902-4337-8615-85c7e7403098
+    Suspicious Model Components Check  BLOCKING
 ```
 
-### Filter rule instances
+### Filter by state
 
 ```bash
-# By state
-daystrom model-security rule-instances list <groupUuid> --state BLOCKING
+daystrom model-security rule-instances list 020d546d-3920-4ef3-9183-00f37f33f566 --state BLOCKING
+```
 
-# By security rule
-daystrom model-security rule-instances list <groupUuid> --security-rule-uuid <ruleUuid>
+```
+  Rule Instances:
+
+  67185c67-020a-4625-816f-9a2137e3d6b3
+    Known Framework Operators Check  BLOCKING
+  34f0a130-d2a3-451d-8795-776f5d5bdd8f
+    Load Time Code Execution Check  BLOCKING
+  0fe19730-3fb4-474b-9160-d2de02be592b
+    Model Architecture Backdoor Check  BLOCKING
+  c532d04b-ca2d-4e03-8b4b-8a81917c02cf
+    Runtime Code Execution Check  BLOCKING
+  53aab919-06c4-4ebf-a1e1-8124ce2ae0d5
+    Stored In Approved File Format  BLOCKING
+  43dd1d74-f902-4337-8615-85c7e7403098
+    Suspicious Model Components Check  BLOCKING
 ```
 
 ### Get rule instance details
 
 ```bash
-daystrom model-security rule-instances get <groupUuid> <instanceUuid>
+daystrom model-security rule-instances get 020d546d-3920-4ef3-9183-00f37f33f566 67185c67-020a-4625-816f-9a2137e3d6b3
+```
+
+```
+  Rule Instance Detail:
+
+    UUID:         67185c67-020a-4625-816f-9a2137e3d6b3
+    Group UUID:   020d546d-3920-4ef3-9183-00f37f33f566
+    Rule UUID:    550e8400-e29b-41d4-a716-44665544000b
+    State:        BLOCKING
+    Rule Name:    Known Framework Operators Check
+    Created:      2025-10-30T14:14:17.321066Z
+    Updated:      2025-10-30T14:14:17.321066Z
 ```
 
 ### Update a rule instance
-
-Create a JSON configuration file:
 
 ```json title="rule-instance-update.json"
 {
@@ -205,80 +257,174 @@ daystrom model-security rule-instances update <groupUuid> <instanceUuid> --confi
 ### List scans
 
 ```bash
-daystrom model-security scans list
+daystrom model-security scans list --limit 3
 ```
 
 ```
-  Prisma AIRS — Model Security
-  ML model supply chain security
-
   Model Security Scans:
 
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    COMPLETED  2025-09-01T14:30:00.000Z
-    Rules: 8 passed  2 failed  / 10 total
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    COMPLETED  2025-09-02T10:00:00.000Z
-    Rules: 10 passed  0 failed  / 10 total
+  7a7e1cdf-a6b1-4743-a5f2-a7bd96ec7bab
+    BLOCKED  HUGGING_FACE  2026-03-03T22:32:12.344402Z
+    https://huggingface.co/microsoft/DialoGPT-medium
+    Rules: 10 passed  1 failed  / 11 total
+  ee71b4da-64ce-4d6c-96fb-2bced1154a06
+    ALLOWED  MODEL_SECURITY_SDK  2026-03-03T22:21:44.130386Z
+    /Users/.../models/qwen3-0.6b-saffron-merged
+    Rules: 6 passed  0 failed  / 6 total
+  6456c1fd-1a76-40c4-a591-3275d7885c17
+    ALLOWED  MODEL_SECURITY_SDK  2026-03-03T22:16:54.578468Z
+    models/qwen3-0.6b-saffron-qlora/
+    Rules: 6 passed  0 failed  / 6 total
 ```
 
 ### Filter scans
 
 ```bash
 # By evaluation outcome
-daystrom model-security scans list --eval-outcome FAILED
+daystrom model-security scans list --eval-outcome BLOCKED
 
 # By source type
-daystrom model-security scans list --source-type LOCAL
-
-# Search
-daystrom model-security scans list --search "model-name"
+daystrom model-security scans list --source-type HUGGING_FACE
 ```
 
 ### Get scan details
 
 ```bash
-daystrom model-security scans get <uuid>
+daystrom model-security scans get 7a7e1cdf-a6b1-4743-a5f2-a7bd96ec7bab
+```
+
+```
+  Scan Detail:
+
+    UUID:       7a7e1cdf-a6b1-4743-a5f2-a7bd96ec7bab
+    Outcome:    BLOCKED
+    Model URI:  https://huggingface.co/microsoft/DialoGPT-medium
+    Origin:     HUGGING_FACE
+    Source:     HUGGING_FACE
+    Group:      Default HUGGING_FACE
+    Created:    2026-03-03T22:32:12.344402Z
+    Updated:    2026-03-03T22:32:12.477430Z
+    Rules:      10 passed  1 failed  / 11 total
 ```
 
 ### View scan evaluations
 
 ```bash
-daystrom model-security scans evaluations <scanUuid>
+daystrom model-security scans evaluations 7a7e1cdf-a6b1-4743-a5f2-a7bd96ec7bab
 ```
 
 ```
-  Prisma AIRS — Model Security
-  ML model supply chain security
-
   Rule Evaluations:
 
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Unsafe Deserialization  ALLOWED
-  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    Malicious Code Injection  BLOCKED
+  83924890-6823-4e6f-9541-3eed300b890e
+    License Exists  PASSED  BLOCKING
+  1a4db8ab-cbe6-4f9f-bfbf-fb65fdb451de
+    License Is Valid For Use  PASSED  BLOCKING
+  0e424aa6-0fb7-427a-8809-3caa301a8c40
+    Model Is Blocked  PASSED  BLOCKING
+  ec06ca86-1271-4d3a-a310-272190f74503
+    Organization Is Blocked  PASSED  BLOCKING
+  494c926e-0f8a-4a22-87ae-2a1ff06c0e7b
+    Organization Verified By Hugging Face  PASSED  BLOCKING
+  1ae405a2-15a9-4a3b-8e57-5a916c133857
+    Stored In Approved File Format  FAILED  BLOCKING
+  6c5b370e-320b-41bb-b206-8a4e5265eeea
+    Known Framework Operators Check  PASSED  BLOCKING
+  779f12dd-b672-494f-9962-2e642ff3716e
+    Load Time Code Execution Check  PASSED  BLOCKING
+  5fbe2ef0-6cb8-441d-b6cf-88ff1c6f9a93
+    Model Architecture Backdoor Check  PASSED  BLOCKING
+  60c3cd09-e9ce-40f2-aff3-d62c21c9c64f
+    Runtime Code Execution Check  PASSED  BLOCKING
+  33fc876c-18b1-4c58-863e-c133fdb07fb1
+    Suspicious Model Components Check  PASSED  BLOCKING
 ```
 
 ### View violations
 
 ```bash
-daystrom model-security scans violations <scanUuid>
+daystrom model-security scans violations 7a7e1cdf-a6b1-4743-a5f2-a7bd96ec7bab
+```
+
+```
+  Violations:
+
+  0115bae0-bc07-468b-8ca6-a585d8c82f59
+    Stored In Approved File Format  pytorch_model.bin
+    Model file 'pytorch_model.bin' is stored in an unapproved format: pickle
+    Threat: UNAPPROVED_FORMATS
+  2b5e4d7b-2a50-408e-b6cf-640f1b8ec4cd
+    Stored In Approved File Format  pytorch_model.bin
+    Model file 'pytorch_model.bin' is stored in an unapproved format: pytorch_v0_1_10
+    Threat: UNAPPROVED_FORMATS
+  33b437c4-47f0-4878-a249-64be8bd46e06
+    Stored In Approved File Format  rust_model.ot
+    Model file 'rust_model.ot' is stored in an unapproved format: pytorch_torch_script
+    Threat: UNAPPROVED_FORMATS
+  f1409208-b28c-4234-b015-137b6b28508c
+    Stored In Approved File Format  rust_model.ot
+    Model file 'rust_model.ot' is stored in an unapproved format: zip
+    Threat: UNAPPROVED_FORMATS
+  9d39c991-e37f-4e6f-bc27-bffed8d90047
+    Stored In Approved File Format  tf_model.h5
+    Model file 'tf_model.h5' is stored in an unapproved format: keras_weights
+    Threat: UNAPPROVED_FORMATS
 ```
 
 ### View scanned files
 
 ```bash
-daystrom model-security scans files <scanUuid>
+daystrom model-security scans files 7a7e1cdf-a6b1-4743-a5f2-a7bd96ec7bab
+```
 
-# Filter by result
-daystrom model-security scans files <scanUuid> --result FAILED
+```
+  Scanned Files:
+
+    SUCCESS  FILE  config.json [json]
+    SKIPPED  FILE  flax_model.msgpack
+    SUCCESS  FILE  generation_config_for_conversational.json [json]
+    SUCCESS  FILE  generation_config.json [json]
+    SKIPPED  FILE  .gitattributes
+    SKIPPED  FILE  merges.txt
+    FAILED  FILE  pytorch_model.bin [pickle, pytorch_v0_1_10]
+    SKIPPED  FILE  README.md [not_model]
+    FAILED  FILE  rust_model.ot [pytorch_torch_script, zip]
+    FAILED  FILE  tf_model.h5 [keras_weights]
+    SUCCESS  FILE  tokenizer_config.json [json]
+    SUCCESS  FILE  vocab.json [json]
 ```
 
 ---
 
 ## Labels
 
-Labels help organize and categorize scans.
+Labels help organize and categorize scans with key-value metadata.
+
+### Browse label taxonomy
+
+```bash
+daystrom model-security labels keys
+```
+
+```
+  Label Keys:
+
+    branch
+    commit
+    env
+    repo
+```
+
+```bash
+daystrom model-security labels values env
+```
+
+```
+  Label Values for "env":
+
+    ci
+    production
+```
 
 ### Add labels
 
@@ -298,16 +444,6 @@ daystrom model-security labels set <scanUuid> --labels '[{"key":"env","value":"s
 daystrom model-security labels delete <scanUuid> --keys env,team
 ```
 
-### Browse label taxonomy
-
-```bash
-# List all label keys
-daystrom model-security labels keys
-
-# List values for a key
-daystrom model-security labels values env
-```
-
 ---
 
 ## PyPI Authentication
@@ -322,19 +458,29 @@ daystrom model-security pypi-auth
 
 ## Common Workflows
 
-### Audit a model source
+### Investigate a blocked scan
 
-1. List available groups to find the right source type:
+1. Find blocked scans:
    ```bash
-   daystrom model-security groups list --source-types S3
+   daystrom model-security scans list --eval-outcome BLOCKED
    ```
 
-2. Check which rules are active:
+2. View evaluations to find which rule failed:
    ```bash
-   daystrom model-security rule-instances list <groupUuid> --state BLOCKING
+   daystrom model-security scans evaluations <scanUuid>
    ```
 
-3. Review a specific rule's remediation steps:
+3. View specific violations:
+   ```bash
+   daystrom model-security scans violations <scanUuid>
+   ```
+
+4. Check the scanned files:
+   ```bash
+   daystrom model-security scans files <scanUuid>
+   ```
+
+5. Look up remediation steps for the failed rule:
    ```bash
    daystrom model-security rules get <ruleUuid>
    ```

--- a/src/airs/modelsecurity.ts
+++ b/src/airs/modelsecurity.ts
@@ -80,7 +80,11 @@ function normalizeScan(raw: Record<string, unknown>): ModelSecurityScan {
   const summary = raw.eval_summary as Record<string, unknown> | null;
   return {
     uuid: raw.uuid as string,
-    status: raw.status as string,
+    evalOutcome: (raw.eval_outcome ?? '') as string,
+    modelUri: (raw.model_uri ?? '') as string,
+    scanOrigin: (raw.scan_origin ?? '') as string,
+    sourceType: (raw.source_type ?? '') as string,
+    securityGroupName: (raw.security_group_name ?? '') as string,
     evalSummary: summary
       ? {
           rulesFailed: (summary.rules_failed ?? 0) as number,
@@ -98,10 +102,12 @@ function normalizeScan(raw: Record<string, unknown>): ModelSecurityScan {
 function normalizeEvaluation(raw: Record<string, unknown>): ModelSecurityEvaluation {
   return {
     uuid: raw.uuid as string,
-    evalOutcome: raw.eval_outcome as string,
     result: raw.result as string,
-    securityRuleUuid: raw.security_rule_uuid as string,
+    violationCount: (raw.violation_count ?? 0) as number,
+    ruleInstanceUuid: (raw.rule_instance_uuid ?? '') as string,
     ruleName: raw.rule_name as string,
+    ruleDescription: (raw.rule_description ?? '') as string,
+    ruleInstanceState: (raw.rule_instance_state ?? '') as string,
   };
 }
 
@@ -109,17 +115,23 @@ function normalizeEvaluation(raw: Record<string, unknown>): ModelSecurityEvaluat
 function normalizeViolation(raw: Record<string, unknown>): ModelSecurityViolation {
   return {
     uuid: raw.uuid as string,
-    ruleName: raw.rule_name as string,
-    filePath: raw.file_path as string,
     description: raw.description as string,
+    threat: (raw.threat ?? '') as string,
+    threatDescription: (raw.threat_description ?? '') as string,
+    file: (raw.file ?? '') as string,
+    ruleName: raw.rule_name as string,
+    ruleDescription: (raw.rule_description ?? '') as string,
+    ruleInstanceState: (raw.rule_instance_state ?? '') as string,
   };
 }
 
 /** Normalize an SDK file response. */
 function normalizeFile(raw: Record<string, unknown>): ModelSecurityFile {
   return {
-    filePath: raw.file_path as string,
+    uuid: raw.uuid as string,
+    path: (raw.path ?? '') as string,
     type: raw.type as string,
+    formats: (raw.formats ?? []) as string[],
     result: raw.result as string,
   };
 }

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -473,7 +473,11 @@ export interface ModelSecurityRuleInstanceUpdateRequest {
 /** Normalized model security scan. */
 export interface ModelSecurityScan {
   uuid: string;
-  status: string;
+  evalOutcome: string;
+  modelUri: string;
+  scanOrigin: string;
+  sourceType: string;
+  securityGroupName: string;
   evalSummary: {
     rulesFailed: number;
     rulesPassed: number;
@@ -497,24 +501,32 @@ export interface ModelSecurityScanListOptions {
 /** Normalized rule evaluation from a scan. */
 export interface ModelSecurityEvaluation {
   uuid: string;
-  evalOutcome: string;
   result: string;
-  securityRuleUuid: string;
+  violationCount: number;
+  ruleInstanceUuid: string;
   ruleName: string;
+  ruleDescription: string;
+  ruleInstanceState: string;
 }
 
 /** Normalized violation from a scan. */
 export interface ModelSecurityViolation {
   uuid: string;
-  ruleName: string;
-  filePath: string;
   description: string;
+  threat: string;
+  threatDescription: string;
+  file: string;
+  ruleName: string;
+  ruleDescription: string;
+  ruleInstanceState: string;
 }
 
 /** Normalized scanned file from a scan. */
 export interface ModelSecurityFile {
-  filePath: string;
+  uuid: string;
+  path: string;
   type: string;
+  formats: string[];
   result: string;
 }
 

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -851,10 +851,17 @@ export function renderMsScanList(scans: ModelSecurityScan[]): void {
   }
   console.log(chalk.bold('\n  Model Security Scans:\n'));
   for (const s of scans) {
-    const statusColor =
-      s.status === 'COMPLETED' ? chalk.green : s.status === 'FAILED' ? chalk.red : chalk.yellow;
+    const outcomeColor =
+      s.evalOutcome === 'ALLOWED'
+        ? chalk.green
+        : s.evalOutcome === 'BLOCKED'
+          ? chalk.red
+          : chalk.yellow;
     console.log(`  ${chalk.dim(s.uuid)}`);
-    console.log(`    ${statusColor(s.status)}  ${chalk.dim(s.createdAt)}`);
+    console.log(
+      `    ${outcomeColor(s.evalOutcome)}  ${chalk.dim(s.scanOrigin)}  ${chalk.dim(s.createdAt)}`,
+    );
+    if (s.modelUri) console.log(`    ${chalk.dim(s.modelUri)}`);
     if (s.evalSummary) {
       const { rulesPassed, rulesFailed, totalRules } = s.evalSummary;
       console.log(
@@ -868,16 +875,24 @@ export function renderMsScanList(scans: ModelSecurityScan[]): void {
 /** Render full scan detail. */
 export function renderMsScanDetail(scan: ModelSecurityScan): void {
   console.log(chalk.bold('\n  Scan Detail:\n'));
-  console.log(`    UUID:    ${chalk.dim(scan.uuid)}`);
-  const statusColor =
-    scan.status === 'COMPLETED' ? chalk.green : scan.status === 'FAILED' ? chalk.red : chalk.yellow;
-  console.log(`    Status:  ${statusColor(scan.status)}`);
-  console.log(`    Created: ${chalk.dim(scan.createdAt)}`);
-  console.log(`    Updated: ${chalk.dim(scan.updatedAt)}`);
+  console.log(`    UUID:       ${chalk.dim(scan.uuid)}`);
+  const outcomeColor =
+    scan.evalOutcome === 'ALLOWED'
+      ? chalk.green
+      : scan.evalOutcome === 'BLOCKED'
+        ? chalk.red
+        : chalk.yellow;
+  console.log(`    Outcome:    ${outcomeColor(scan.evalOutcome)}`);
+  if (scan.modelUri) console.log(`    Model URI:  ${scan.modelUri}`);
+  console.log(`    Origin:     ${scan.scanOrigin}`);
+  console.log(`    Source:     ${scan.sourceType}`);
+  console.log(`    Group:      ${scan.securityGroupName}`);
+  console.log(`    Created:    ${chalk.dim(scan.createdAt)}`);
+  console.log(`    Updated:    ${chalk.dim(scan.updatedAt)}`);
   if (scan.evalSummary) {
     const { rulesPassed, rulesFailed, totalRules } = scan.evalSummary;
     console.log(
-      `    Rules:   ${chalk.green(`${rulesPassed} passed`)}  ${chalk.red(`${rulesFailed} failed`)}  / ${totalRules} total`,
+      `    Rules:      ${chalk.green(`${rulesPassed} passed`)}  ${chalk.red(`${rulesFailed} failed`)}  / ${totalRules} total`,
     );
   }
   if (scan.labels.length > 0) {
@@ -902,13 +917,9 @@ export function renderEvaluationList(evaluations: ModelSecurityEvaluation[]): vo
   console.log(chalk.bold('\n  Rule Evaluations:\n'));
   for (const e of evaluations) {
     const color =
-      e.evalOutcome === 'ALLOWED'
-        ? chalk.green
-        : e.evalOutcome === 'BLOCKED'
-          ? chalk.red
-          : chalk.yellow;
+      e.result === 'PASSED' ? chalk.green : e.result === 'FAILED' ? chalk.red : chalk.yellow;
     console.log(`  ${chalk.dim(e.uuid)}`);
-    console.log(`    ${e.ruleName}  ${color(e.evalOutcome)}`);
+    console.log(`    ${e.ruleName}  ${color(e.result)}  ${chalk.dim(e.ruleInstanceState)}`);
   }
   console.log();
 }
@@ -916,17 +927,19 @@ export function renderEvaluationList(evaluations: ModelSecurityEvaluation[]): vo
 /** Render a single evaluation detail. */
 export function renderEvaluationDetail(evaluation: ModelSecurityEvaluation): void {
   console.log(chalk.bold('\n  Evaluation Detail:\n'));
-  console.log(`    UUID:      ${chalk.dim(evaluation.uuid)}`);
-  console.log(`    Rule:      ${evaluation.ruleName}`);
-  console.log(`    Rule UUID: ${chalk.dim(evaluation.securityRuleUuid)}`);
+  console.log(`    UUID:           ${chalk.dim(evaluation.uuid)}`);
+  console.log(`    Rule:           ${evaluation.ruleName}`);
+  console.log(`    Description:    ${chalk.dim(evaluation.ruleDescription)}`);
+  console.log(`    Instance UUID:  ${chalk.dim(evaluation.ruleInstanceUuid)}`);
+  console.log(`    Instance State: ${evaluation.ruleInstanceState}`);
   const color =
-    evaluation.evalOutcome === 'ALLOWED'
+    evaluation.result === 'PASSED'
       ? chalk.green
-      : evaluation.evalOutcome === 'BLOCKED'
+      : evaluation.result === 'FAILED'
         ? chalk.red
         : chalk.yellow;
-  console.log(`    Outcome:   ${color(evaluation.evalOutcome)}`);
-  console.log(`    Result:    ${evaluation.result}`);
+  console.log(`    Result:         ${color(evaluation.result)}`);
+  console.log(`    Violations:     ${evaluation.violationCount}`);
   console.log();
 }
 
@@ -943,8 +956,9 @@ export function renderViolationList(violations: ModelSecurityViolation[]): void 
   console.log(chalk.bold('\n  Violations:\n'));
   for (const v of violations) {
     console.log(`  ${chalk.dim(v.uuid)}`);
-    console.log(`    ${chalk.red(v.ruleName)}  ${chalk.dim(v.filePath)}`);
+    console.log(`    ${chalk.red(v.ruleName)}  ${chalk.dim(v.file)}`);
     console.log(`    ${v.description}`);
+    console.log(`    Threat: ${chalk.dim(v.threat)}`);
   }
   console.log();
 }
@@ -954,8 +968,11 @@ export function renderViolationDetail(violation: ModelSecurityViolation): void {
   console.log(chalk.bold('\n  Violation Detail:\n'));
   console.log(`    UUID:        ${chalk.dim(violation.uuid)}`);
   console.log(`    Rule:        ${chalk.red(violation.ruleName)}`);
-  console.log(`    File:        ${violation.filePath}`);
-  console.log(`    Description: ${violation.description}`);
+  console.log(`    Description: ${violation.ruleDescription}`);
+  console.log(`    State:       ${violation.ruleInstanceState}`);
+  console.log(`    File:        ${violation.file}`);
+  console.log(`    Threat:      ${violation.threat}`);
+  console.log(`    Detail:      ${violation.description}`);
   console.log();
 }
 
@@ -972,8 +989,9 @@ export function renderFileList(files: ModelSecurityFile[]): void {
   console.log(chalk.bold('\n  Scanned Files:\n'));
   for (const f of files) {
     const color =
-      f.result === 'PASSED' ? chalk.green : f.result === 'FAILED' ? chalk.red : chalk.yellow;
-    console.log(`    ${color(f.result)}  ${f.type}  ${chalk.dim(f.filePath)}`);
+      f.result === 'SUCCESS' ? chalk.green : f.result === 'SKIPPED' ? chalk.yellow : chalk.red;
+    const formats = f.formats.length > 0 ? chalk.dim(` [${f.formats.join(', ')}]`) : '';
+    console.log(`    ${color(f.result)}  ${f.type}  ${f.path}${formats}`);
   }
   console.log();
 }

--- a/tests/unit/airs/modelsecurity.spec.ts
+++ b/tests/unit/airs/modelsecurity.spec.ts
@@ -451,7 +451,11 @@ describe('SdkModelSecurityService', () => {
         scans: [
           {
             uuid: 's-1',
-            status: 'COMPLETED',
+            eval_outcome: 'BLOCKED',
+            model_uri: 'https://huggingface.co/test/model',
+            scan_origin: 'HUGGING_FACE',
+            source_type: 'HUGGING_FACE',
+            security_group_name: 'Default HUGGING_FACE',
             eval_summary: { rules_failed: 1, rules_passed: 5, total_rules: 6 },
             created_at: '2026-01-01T00:00:00Z',
             updated_at: '2026-01-02T00:00:00Z',
@@ -464,7 +468,11 @@ describe('SdkModelSecurityService', () => {
       expect(result.totalItems).toBe(1);
       expect(result.scans[0]).toEqual({
         uuid: 's-1',
-        status: 'COMPLETED',
+        evalOutcome: 'BLOCKED',
+        modelUri: 'https://huggingface.co/test/model',
+        scanOrigin: 'HUGGING_FACE',
+        sourceType: 'HUGGING_FACE',
+        securityGroupName: 'Default HUGGING_FACE',
         evalSummary: { rulesFailed: 1, rulesPassed: 5, totalRules: 6 },
         createdAt: '2026-01-01T00:00:00Z',
         updatedAt: '2026-01-02T00:00:00Z',
@@ -495,7 +503,11 @@ describe('SdkModelSecurityService', () => {
     it('returns normalized scan', async () => {
       mockScansGet.mockResolvedValue({
         uuid: 's-1',
-        status: 'COMPLETED',
+        eval_outcome: 'ALLOWED',
+        model_uri: 'gs://bucket/model',
+        scan_origin: 'GCS',
+        source_type: 'GCS',
+        security_group_name: 'Default GCS',
         eval_summary: { rules_failed: 0, rules_passed: 3, total_rules: 3 },
         created_at: '2026-01-01T00:00:00Z',
         updated_at: '2026-01-02T00:00:00Z',
@@ -504,7 +516,8 @@ describe('SdkModelSecurityService', () => {
 
       const result = await service.getScan('s-1');
       expect(result.uuid).toBe('s-1');
-      expect(result.evalSummary.totalRules).toBe(3);
+      expect(result.evalOutcome).toBe('ALLOWED');
+      expect(result.evalSummary?.totalRules).toBe(3);
     });
   });
 
@@ -512,7 +525,11 @@ describe('SdkModelSecurityService', () => {
     it('passes request to SDK and returns normalized result', async () => {
       mockScansCreate.mockResolvedValue({
         uuid: 's-new',
-        status: 'PENDING',
+        eval_outcome: 'PENDING',
+        model_uri: '',
+        scan_origin: 'LOCAL',
+        source_type: 'LOCAL',
+        security_group_name: 'Default LOCAL',
         eval_summary: null,
         created_at: '2026-01-01T00:00:00Z',
         updated_at: '2026-01-01T00:00:00Z',
@@ -535,10 +552,12 @@ describe('SdkModelSecurityService', () => {
         evaluations: [
           {
             uuid: 'e-1',
-            eval_outcome: 'BLOCKED',
             result: 'FAILED',
-            security_rule_uuid: 'r-1',
+            violation_count: 2,
+            rule_instance_uuid: 'ri-1',
             rule_name: 'Format Check',
+            rule_description: 'Check file format',
+            rule_instance_state: 'BLOCKING',
           },
         ],
       });
@@ -547,10 +566,12 @@ describe('SdkModelSecurityService', () => {
       expect(result.totalItems).toBe(1);
       expect(result.evaluations[0]).toEqual({
         uuid: 'e-1',
-        evalOutcome: 'BLOCKED',
         result: 'FAILED',
-        securityRuleUuid: 'r-1',
+        violationCount: 2,
+        ruleInstanceUuid: 'ri-1',
         ruleName: 'Format Check',
+        ruleDescription: 'Check file format',
+        ruleInstanceState: 'BLOCKING',
       });
     });
   });
@@ -559,14 +580,16 @@ describe('SdkModelSecurityService', () => {
     it('returns normalized single evaluation', async () => {
       mockScansGetEvaluation.mockResolvedValue({
         uuid: 'e-1',
-        eval_outcome: 'ALLOWED',
         result: 'PASSED',
-        security_rule_uuid: 'r-1',
+        violation_count: 0,
+        rule_instance_uuid: 'ri-1',
         rule_name: 'License Check',
+        rule_description: 'Check license',
+        rule_instance_state: 'BLOCKING',
       });
 
       const result = await service.getEvaluation('e-1');
-      expect(result.evalOutcome).toBe('ALLOWED');
+      expect(result.result).toBe('PASSED');
     });
   });
 
@@ -580,9 +603,13 @@ describe('SdkModelSecurityService', () => {
         violations: [
           {
             uuid: 'v-1',
-            rule_name: 'Malicious Code',
-            file_path: 'model.pkl',
             description: 'Pickle exploit detected',
+            threat: 'MALICIOUS_CODE',
+            threat_description: 'Code injection threat',
+            file: 'model.pkl',
+            rule_name: 'Malicious Code',
+            rule_description: 'Scans for malicious code',
+            rule_instance_state: 'BLOCKING',
           },
         ],
       });
@@ -591,9 +618,13 @@ describe('SdkModelSecurityService', () => {
       expect(result.totalItems).toBe(1);
       expect(result.violations[0]).toEqual({
         uuid: 'v-1',
-        ruleName: 'Malicious Code',
-        filePath: 'model.pkl',
         description: 'Pickle exploit detected',
+        threat: 'MALICIOUS_CODE',
+        threatDescription: 'Code injection threat',
+        file: 'model.pkl',
+        ruleName: 'Malicious Code',
+        ruleDescription: 'Scans for malicious code',
+        ruleInstanceState: 'BLOCKING',
       });
     });
   });
@@ -602,14 +633,19 @@ describe('SdkModelSecurityService', () => {
     it('returns normalized single violation', async () => {
       mockScansGetViolation.mockResolvedValue({
         uuid: 'v-1',
-        rule_name: 'Format Check',
-        file_path: 'model.bin',
         description: 'Unapproved format',
+        threat: 'UNAPPROVED_FORMATS',
+        threat_description: 'Unapproved file format',
+        file: 'model.bin',
+        rule_name: 'Format Check',
+        rule_description: 'Check file format',
+        rule_instance_state: 'BLOCKING',
       });
 
       const result = await service.getViolation('v-1');
       expect(result.uuid).toBe('v-1');
       expect(result.ruleName).toBe('Format Check');
+      expect(result.threat).toBe('UNAPPROVED_FORMATS');
     });
   });
 
@@ -622,8 +658,10 @@ describe('SdkModelSecurityService', () => {
         pagination: { total_items: 1 },
         files: [
           {
-            file_path: 'model.safetensors',
+            uuid: 'f-1',
+            path: 'model.safetensors',
             type: 'FILE',
+            formats: ['safetensors'],
             result: 'SUCCESS',
           },
         ],
@@ -632,8 +670,10 @@ describe('SdkModelSecurityService', () => {
       const result = await service.getFiles('s-1');
       expect(result.totalItems).toBe(1);
       expect(result.files[0]).toEqual({
-        filePath: 'model.safetensors',
+        uuid: 'f-1',
+        path: 'model.safetensors',
         type: 'FILE',
+        formats: ['safetensors'],
         result: 'SUCCESS',
       });
     });


### PR DESCRIPTION
## Summary
- Fix scan type: `status`→`evalOutcome`, add `modelUri`/`scanOrigin`/`sourceType`/`securityGroupName`
- Fix evaluation type: remove `evalOutcome`/`securityRuleUuid`, add `violationCount`/`ruleInstanceUuid`/`ruleDescription`/`ruleInstanceState`
- Fix violation type: add `threat`/`threatDescription`/`ruleDescription`/`ruleInstanceState`, `file_path`→`file`
- Fix file type: add `uuid`/`formats`, `file_path`→`path`, result values `SUCCESS`/`SKIPPED`/`FAILED`
- Replace all placeholder output in docs with real AIRS CLI output
- Update all 30 unit tests to match actual API response shapes

## Test plan
- [x] All 390 tests pass
- [x] Lint/typecheck clean
- [x] Every CLI command validated against live AIRS:
  - groups list/get, groups list --source-types
  - rules list/get, rules list --search
  - rule-instances list/get, rule-instances list --state
  - scans list/get
  - scans evaluations/violations/files
  - labels keys/values

🤖 Generated with [Claude Code](https://claude.com/claude-code)