### PR TITLE
fix: resolve review findings from 2026-03-09 audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ tests/
 
 ### Core Loop (`src/core/loop.ts`)
 - `runLoop()` async generator yields typed `LoopEvent` discriminated unions
-- Events yielded by `runLoop()`: `iteration:start`, `generate:complete`, `apply:complete`, `tests:accumulated` (if accumulation enabled, iter 2+), `test:progress`, `evaluate:complete`, `analyze:complete`, `iteration:complete`, `memory:extracted` (if memory enabled), `promptset:created` (if `--create-prompt-set`), `loop:complete`
+- Events yielded by `runLoop()`: `iteration:start`, `generate:complete`, `apply:complete`, `tests:composed` (iter 2+, always-on composition), `tests:accumulated` (if accumulation enabled, iter 2+), `test:progress`, `evaluate:complete`, `analyze:complete`, `iteration:complete`, `memory:extracted` (if memory enabled), `promptset:created` (if `--create-prompt-set`), `loop:complete`
 - Events defined in `LoopEvent` union but **not yielded** by `runLoop()`: `loop:paused` (reserved for future use), `memory:loaded` (emitted by CLI before loop starts)
 - `apply:complete` is yielded but intentionally unhandled in CLI commands (no user-facing output needed)
 - Topic name **locked after iteration 1** — only description+examples change thereafter
@@ -158,7 +158,7 @@ tests/
 
 ### LLM Service (`src/llm/`)
 - 6 providers: `claude-api` (default), `claude-vertex`, `claude-bedrock`, `gemini-api`, `gemini-vertex`, `gemini-bedrock`
-- Default model: `claude-opus-4-6` (Vertex: `claude-opus-4-6`, Bedrock: `anthropic.claude-opus-4-6-v1`)
+- Default model: `claude-opus-4-6` (Vertex: `claude-opus-4-6`, Bedrock: `anthropic.claude-opus-4-6-v1`), Gemini providers: `gemini-2.0-flash`
 - `claude-vertex` default region: `global` (not `us-central1`)
 - All 4 calls use `withStructuredOutput(ZodSchema)` — 3 retries on parse failure
 - Memory injected via `{memorySection}` template variable

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ cd daystrom
 pnpm install
 cp .env.example .env   # edit with your credentials
 pnpm run generate      # run via tsx
-pnpm test              # 258 tests
+pnpm test              # run test suite
 pnpm run lint          # biome check
 ```
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -156,7 +156,7 @@ daystrom audit <profileName> [options]
 
 | Flag | Default | What it does |
 |------|---------|-------------|
-| `--max-tests-per-topic <n>` | `40` | Max test cases generated per topic |
+| `--max-tests-per-topic <n>` | `20` | Max test cases generated per topic |
 | `--format <fmt>` | `terminal` | Output format: `terminal`, `json`, `html` |
 | `--output <path>` | `<profile>-audit.html` | Output file path (html format only) |
 | `--provider <name>` | `claude-api` | LLM provider |

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -43,18 +43,6 @@ All environment variables Daystrom recognizes, grouped by category. Copy `.env.e
 
 ---
 
-## AIRS Red Team API
-
-Red team operations reuse the same OAuth2 credentials as the Management API above. These optional overrides let you point at dedicated red team endpoints:
-
-| Variable | Required | What it does |
-|----------|:--------:|-------------|
-| `PANW_RED_TEAM_DATA_ENDPOINT` | -- | Custom red team data endpoint |
-| `PANW_RED_TEAM_MGMT_ENDPOINT` | -- | Custom red team management endpoint |
-| `PANW_RED_TEAM_TOKEN_ENDPOINT` | -- | Custom red team token endpoint |
-
----
-
 ## Tuning
 
 | Variable | Default | Range | What it controls |

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import 'dotenv/config';
 import { Command } from 'commander';
 import { registerAuditCommand } from './commands/audit.js';
@@ -10,6 +13,9 @@ import { registerRedteamCommand } from './commands/redteam.js';
 import { registerReportCommand } from './commands/report.js';
 import { registerResumeCommand } from './commands/resume.js';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
+
 const program = new Command();
 
 program
@@ -17,7 +23,7 @@ program
   .description(
     'CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits',
   )
-  .version('1.7.5');
+  .version(pkg.version);
 
 registerGenerateCommand(program);
 registerResumeCommand(program);

--- a/src/memory/extractor.ts
+++ b/src/memory/extractor.ts
@@ -103,7 +103,7 @@ export class LearningExtractor {
     for (const newL of incoming) {
       const match = merged.findIndex((e) => e.insight === newL.insight);
       if (match >= 0) {
-        // Corroborate: increment count, keep the better metrics
+        // Corroborate: increment count, keep existing metrics
         merged[match] = {
           ...merged[match],
           corroborations: merged[match].corroborations + 1,

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -37,7 +37,7 @@ export function normalizeCategory(description: string): string {
     .filter((w) => w.length > 0 && !STOP_WORDS.has(w));
 
   const unique = [...new Set(words)].sort();
-  return unique.join('-');
+  return unique.length > 0 ? unique.join('-') : 'uncategorized';
 }
 
 /**

--- a/tests/unit/memory/store.spec.ts
+++ b/tests/unit/memory/store.spec.ts
@@ -45,6 +45,14 @@ describe('normalizeCategory', () => {
     const result = normalizeCategory('BLOCK Weapons');
     expect(result).toBe('block-weapons');
   });
+
+  it('returns "uncategorized" for stop-word-only input', () => {
+    expect(normalizeCategory('the and or')).toBe('uncategorized');
+  });
+
+  it('returns "uncategorized" for empty string', () => {
+    expect(normalizeCategory('')).toBe('uncategorized');
+  });
 });
 
 describe('MemoryStore', () => {


### PR DESCRIPTION
## Summary
- **#68** Read CLI version from package.json dynamically (no more version drift)
- **#69** Fix audit `--max-tests-per-topic` docs default 40→20
- **#70** Add `tests:composed` event to CLAUDE.md events list
- **#71** Remove phantom red team env vars from docs
- **#72** Document Gemini provider defaults (`gemini-2.0-flash`)
- **#73** Return `'uncategorized'` fallback for empty `normalizeCategory()` + tests
- **#74** Remove hardcoded test count from README
- **#75** Fix misleading comment in memory extractor

Closes #68, #69, #70, #71, #72, #73, #74, #75

## Test plan
- [x] 392 tests pass (2 new for empty category edge case)
- [x] TypeScript typecheck clean
- [x] Biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)