### PR TITLE
fix: upgrade default Gemini model to gemini-2.5-pro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ tests/
 
 ### LLM Service (`src/llm/`)
 - 6 providers: `claude-api` (default), `claude-vertex`, `claude-bedrock`, `gemini-api`, `gemini-vertex`, `gemini-bedrock`
-- Default model: `claude-opus-4-6` (Vertex: `claude-opus-4-6`, Bedrock: `anthropic.claude-opus-4-6-v1`), Gemini providers: `gemini-2.0-flash`
+- Default model: `claude-opus-4-6` (Vertex: `claude-opus-4-6`, Bedrock: `anthropic.claude-opus-4-6-v1`), Gemini providers: `gemini-2.5-pro`
 - `claude-vertex` default region: `global` (not `us-central1`)
 - All 4 calls use `withStructuredOutput(ZodSchema)` — 3 retries on parse failure
 - Memory injected via `{memorySection}` template variable

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -37,9 +37,9 @@ For settings you use across every run, create `~/.daystrom/config.json`:
 | Claude API | `claude-api` | `claude-opus-4-6` | `ANTHROPIC_API_KEY` |
 | Claude Vertex | `claude-vertex` | `claude-opus-4-6` | GCP ADC |
 | Claude Bedrock | `claude-bedrock` | `anthropic.claude-opus-4-6-v1` | AWS creds |
-| Gemini API | `gemini-api` | `gemini-2.0-flash` | `GOOGLE_API_KEY` |
-| Gemini Vertex | `gemini-vertex` | `gemini-2.0-flash` | GCP ADC |
-| Gemini Bedrock | `gemini-bedrock` | `gemini-2.0-flash` | AWS creds |
+| Gemini API | `gemini-api` | `gemini-2.5-pro` | `GOOGLE_API_KEY` |
+| Gemini Vertex | `gemini-vertex` | `gemini-2.5-pro` | GCP ADC |
+| Gemini Bedrock | `gemini-bedrock` | `gemini-2.5-pro` | AWS creds |
 
 !!! note "Claude Vertex region"
     The `claude-vertex` provider defaults to the `global` region, not `us-central1`. Override with `GOOGLE_CLOUD_LOCATION` if needed.

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -115,7 +115,7 @@ Gemini models on AWS Bedrock, also via `@langchain/aws` (`ChatBedrockConverse`).
 pnpm run generate -- --provider gemini-bedrock
 
 # Override model
-pnpm run generate -- --provider gemini-bedrock --model gemini-2.0-flash
+pnpm run generate -- --provider gemini-bedrock --model gemini-2.5-pro
 ```
 
 ---

--- a/docs/providers/overview.md
+++ b/docs/providers/overview.md
@@ -9,9 +9,9 @@ Daystrom supports **6 provider configurations** across three platforms. All use 
 | `claude-api` | `@langchain/anthropic` | API key | `claude-opus-4-6` |
 | `claude-vertex` | `@anthropic-ai/vertex-sdk` + `@langchain/anthropic` | GCP ADC | `claude-opus-4-6` |
 | `claude-bedrock` | `@langchain/aws` | IAM / default chain | `anthropic.claude-opus-4-6-v1` |
-| `gemini-api` | `@langchain/google-genai` | API key | `gemini-2.0-flash` |
-| `gemini-vertex` | `@langchain/google-vertexai` | GCP ADC | `gemini-2.0-flash` |
-| `gemini-bedrock` | `@langchain/aws` | IAM / default chain | `gemini-2.0-flash` |
+| `gemini-api` | `@langchain/google-genai` | API key | `gemini-2.5-pro` |
+| `gemini-vertex` | `@langchain/google-vertexai` | GCP ADC | `gemini-2.5-pro` |
+| `gemini-bedrock` | `@langchain/aws` | IAM / default chain | `gemini-2.5-pro` |
 
 ## Override the Default Model
 
@@ -33,7 +33,7 @@ export LLM_MODEL=claude-sonnet-4-20250514
     | Anthropic API | `claude-opus-4-6` |
     | Vertex AI (Claude) | `claude-opus-4-6` |
     | Bedrock (Claude) | `anthropic.claude-opus-4-6-v1` |
-    | Google AI / Vertex / Bedrock (Gemini) | `gemini-2.0-flash` |
+    | Google AI / Vertex / Bedrock (Gemini) | `gemini-2.5-pro` |
 
 ## Save Your Preference
 

--- a/docs/providers/saas-apis.md
+++ b/docs/providers/saas-apis.md
@@ -85,7 +85,7 @@ pnpm run generate
 pnpm run generate -- --provider gemini-api
 
 # Override model
-pnpm run generate -- --provider gemini-api --model gemini-2.0-flash
+pnpm run generate -- --provider gemini-api --model gemini-2.5-pro
 ```
 
 !!! tip "Getting an API key"

--- a/docs/providers/vertex-ai.md
+++ b/docs/providers/vertex-ai.md
@@ -96,7 +96,7 @@ Gemini models on Vertex AI via `@langchain/google-vertexai` (`ChatVertexAI`). Th
 pnpm run generate -- --provider gemini-vertex
 
 # Override model and region
-pnpm run generate -- --provider gemini-vertex --model gemini-2.0-flash \
+pnpm run generate -- --provider gemini-vertex --model gemini-2.5-pro \
   GOOGLE_CLOUD_LOCATION=europe-west1
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -60,9 +60,9 @@ Optional JSON file at `~/.daystrom/config.json`. Keys use camelCase matching the
 | `claude-api` | `claude-opus-4-6` |
 | `claude-vertex` | `claude-opus-4-6` |
 | `claude-bedrock` | `anthropic.claude-opus-4-6-v1` |
-| `gemini-api` | `gemini-2.0-flash` |
-| `gemini-vertex` | `gemini-2.0-flash` |
-| `gemini-bedrock` | `gemini-2.0-flash` |
+| `gemini-api` | `gemini-2.5-pro` |
+| `gemini-vertex` | `gemini-2.5-pro` |
+| `gemini-bedrock` | `gemini-2.5-pro` |
 
 !!! warning "Concurrency tuning"
     `scanConcurrency` above 5 risks AIRS rate limiting. Increase cautiously.

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -22,9 +22,9 @@ const DEFAULT_MODELS: Record<LlmProvider, string> = {
   'claude-api': 'claude-opus-4-6',
   'claude-vertex': 'claude-opus-4-6',
   'claude-bedrock': 'anthropic.claude-opus-4-6-v1',
-  'gemini-api': 'gemini-2.0-flash',
-  'gemini-vertex': 'gemini-2.0-flash',
-  'gemini-bedrock': 'gemini-2.0-flash',
+  'gemini-api': 'gemini-2.5-pro',
+  'gemini-vertex': 'gemini-2.5-pro',
+  'gemini-bedrock': 'gemini-2.5-pro',
 };
 
 /**


### PR DESCRIPTION
## Summary
- Change default Gemini model from `gemini-2.0-flash` to `gemini-2.5-pro` across all 3 Gemini providers
- Update all docs references (6 files)

`gemini-2.0-flash` produces poor structured output quality for guardrail generation tasks.

## Test plan
- [x] 392 tests pass
- [x] TypeScript typecheck clean
- [x] Biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)