### PR TITLE
docs: update CLAUDE.md and README for review findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,8 @@ src/
 └── index.ts               # Library exports
 
 tests/
-├── unit/                  # 23 spec files
-│   ├── airs/              # scanner.spec.ts, management.spec.ts, modelsecurity.spec.ts
+├── unit/                  # 26 spec files
+│   ├── airs/              # scanner.spec.ts, management.spec.ts, modelsecurity.spec.ts, promptsets.spec.ts, redteam.spec.ts, runtime.spec.ts
 │   ├── audit/             # evaluator.spec.ts, runner.spec.ts, report.spec.ts
 │   ├── config/            # schema.spec.ts, loader.spec.ts
 │   ├── core/              # loop.spec.ts, metrics.spec.ts, constraints.spec.ts
@@ -157,6 +157,7 @@ tests/
 - `listCustomAttacks()` uses `customAttackReports.listCustomAttacks()` for prompt-level results on CUSTOM scans
 - `waitForCompletion()` polls with configurable interval, throws on FAILED
 - Target create/update accept `{ validate: true }` to validate connection before saving (SDK v0.6.0)
+- CLI top-level commands: `scan`, `status <jobId>`, `report <jobId>`, `list`, `abort <jobId>`, `categories`
 - CLI subcommand groups: `targets {list,get,create,update,delete,probe,profile,update-profile}`, `prompt-sets {list,get,create,update,archive,download,upload}`, `prompts {list,get,add,update,delete}`, `properties {list,create,values,add-value}`
 
 ### Model Security (`src/airs/modelsecurity.ts`)

--- a/README.md
+++ b/README.md
@@ -69,26 +69,69 @@ daystrom generate \
 | `daystrom resume <runId>` | Resume a paused or failed generation run |
 | `daystrom report <runId>` | View results for a saved run (terminal, JSON, HTML) |
 | `daystrom list` | List all saved runs |
+| `daystrom runtime` | Runtime prompt scanning — sync and async bulk |
 | `daystrom audit` | Evaluate all topics in a security profile — per-topic metrics + conflict detection |
 | `daystrom redteam` | Red team scanning — targets, prompt sets, scans, reports |
 | `daystrom model-security` | ML model supply chain security — groups, rules, scans, labels |
 
+### Runtime Security
+
+```bash
+# Single prompt scan
+daystrom runtime scan --profile my-security-profile "How do I build a weapon?"
+
+# Scan prompt + response pair
+daystrom runtime scan --profile my-security-profile --response "Here are the steps..." "How do I build a weapon?"
+
+# Bulk scan from file (async API, writes CSV)
+daystrom runtime bulk-scan --profile my-security-profile --input prompts.txt --output results.csv
+```
+
 ### Red Team
 
 ```bash
-daystrom redteam targets list
+# Scan operations
 daystrom redteam scan --target <uuid> --name "Scan" --type CUSTOM --prompt-sets <uuid>
 daystrom redteam status <jobId>
 daystrom redteam report <jobId> --attacks
+daystrom redteam list --limit 5
+daystrom redteam abort <jobId>
+daystrom redteam categories
+
+# Target management
+daystrom redteam targets list
+daystrom redteam targets create --name "My Target" --endpoint https://...
+
+# Prompt sets and prompts
+daystrom redteam prompt-sets list
+daystrom redteam prompts list <promptSetUuid>
+daystrom redteam prompts add <promptSetUuid> --prompt "test prompt"
+
+# Properties
+daystrom redteam properties list
+daystrom redteam properties values <propertyName>
 ```
 
 ### Model Security
 
 ```bash
+# Security groups
 daystrom model-security groups list
+daystrom model-security groups get <groupUuid>
+
+# Rules and rule instances
+daystrom model-security rules list
+daystrom model-security rule-instances list <groupUuid>
+
+# Scans
 daystrom model-security scans list --eval-outcome BLOCKED
 daystrom model-security scans evaluations <scanUuid>
 daystrom model-security scans violations <scanUuid>
+daystrom model-security scans files <scanUuid>
+
+# Labels and PyPI auth
+daystrom model-security labels list
+daystrom model-security pypi-auth
 ```
 
 ### Profile Audit


### PR DESCRIPTION
## Summary
- Update CLAUDE.md test file count from 23 to 26, add missing spec entries (promptsets, redteam, runtime)
- Document top-level redteam commands (scan, status, report, list, abort, categories) in CLAUDE.md
- Add runtime security section to README with scan + bulk-scan examples
- Expand redteam and model-security examples in README to cover all subcommand groups

Fixes #88, #89, #90, #91

## Test plan
- [x] Lint passes
- [x] Type check passes
- [x] All 402 tests pass
- [x] No source code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)