### PR TITLE
docs: add JSDoc to computeMetrics()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/metrics.ts
+++ b/src/core/metrics.ts
@@ -1,5 +1,13 @@
 import type { CategoryBreakdown, EfficacyMetrics, TestResult } from './types.js';
 
+/**
+ * Classify test results into TP/TN/FP/FN and compute efficacy metrics.
+ *
+ * @param results - Scan results paired with their expected outcomes.
+ * @returns Confusion matrix counts, rates (TPR, TNR, accuracy, coverage, F1),
+ *          and regression failure count. Division-by-zero yields 0.
+ *          Coverage = min(TPR, TNR) — the loop's stop condition target.
+ */
 export function computeMetrics(results: TestResult[]): EfficacyMetrics {
   let truePositives = 0;
   let trueNegatives = 0;


### PR DESCRIPTION
## Summary
- Add JSDoc to `computeMetrics()` documenting params, return type, division-by-zero handling, and coverage formula
- Patch version bump 1.8.1 → 1.8.2

Fixes #92

## Test plan
- [x] Lint passes
- [x] Type check passes
- [x] All 402 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)