### PR TITLE
test: add 20 edge case tests for runtime, audit report, audit runner

### DIFF
--- a/tests/unit/airs/runtime.spec.ts
+++ b/tests/unit/airs/runtime.spec.ts
@@ -172,6 +172,66 @@ describe('SdkRuntimeService', () => {
     });
   });
 
+  describe('submitBulkScan — edge cases', () => {
+    it('returns empty array for empty prompts', async () => {
+      const scanIds = await service.submitBulkScan('p', []);
+      expect(mockScannerInstance.asyncScan).not.toHaveBeenCalled();
+      expect(scanIds).toEqual([]);
+    });
+
+    it('exactly 5 prompts creates 1 batch (not 2)', async () => {
+      mockScannerInstance.asyncScan.mockResolvedValue({
+        received: '2026-03-09T00:00:00Z',
+        scan_id: 'batch-5',
+      });
+
+      const prompts = Array.from({ length: 5 }, (_, i) => `p${i}`);
+      const scanIds = await service.submitBulkScan('profile', prompts);
+      expect(mockScannerInstance.asyncScan).toHaveBeenCalledTimes(1);
+      expect(scanIds).toHaveLength(1);
+      expect(mockScannerInstance.asyncScan.mock.calls[0][0]).toHaveLength(5);
+    });
+
+    it('6 prompts creates 2 batches (5 + 1)', async () => {
+      mockScannerInstance.asyncScan
+        .mockResolvedValueOnce({ received: '2026-03-09T00:00:00Z', scan_id: 'batch-a' })
+        .mockResolvedValueOnce({ received: '2026-03-09T00:00:00Z', scan_id: 'batch-b' });
+
+      const prompts = Array.from({ length: 6 }, (_, i) => `p${i}`);
+      const scanIds = await service.submitBulkScan('profile', prompts);
+      expect(mockScannerInstance.asyncScan).toHaveBeenCalledTimes(2);
+      expect(scanIds).toEqual(['batch-a', 'batch-b']);
+      expect(mockScannerInstance.asyncScan.mock.calls[0][0]).toHaveLength(5);
+      expect(mockScannerInstance.asyncScan.mock.calls[1][0]).toHaveLength(1);
+    });
+  });
+
+  describe('pollResults — edge cases', () => {
+    it('handles mix of COMPLETED and FAILED statuses in single poll', async () => {
+      mockScannerInstance.queryByScanIds.mockResolvedValueOnce([
+        {
+          scan_id: 's1',
+          status: 'COMPLETED',
+          result: { scan_id: 's1', report_id: 'r1', action: 'block', category: 'malicious' },
+        },
+        { scan_id: 's2', status: 'FAILED' },
+        {
+          scan_id: 's3',
+          status: 'COMPLETED',
+          result: { scan_id: 's3', report_id: 'r3', action: 'allow', category: 'benign' },
+        },
+      ]);
+
+      const results = await service.pollResults(['s1', 's2', 's3'], 10);
+      expect(results).toHaveLength(3);
+      expect(results[0].action).toBe('block');
+      expect(results[1].action).toBe('allow');
+      expect(results[1].category).toBe('error');
+      expect(results[2].action).toBe('allow');
+      expect(results[2].category).toBe('benign');
+    });
+  });
+
   describe('formatResultsCsv', () => {
     it('produces CSV with header and data rows', () => {
       const results = [
@@ -220,6 +280,31 @@ describe('SdkRuntimeService', () => {
 
       const csv = SdkRuntimeService.formatResultsCsv(results);
       expect(csv).toContain('"say ""hello"""');
+    });
+
+    it('handles prompts with commas (CSV escaping)', () => {
+      const results = [
+        {
+          prompt: 'hello, world, test',
+          response: undefined,
+          scanId: 's1',
+          reportId: 'r1',
+          action: 'allow' as const,
+          category: 'benign',
+          triggered: false,
+          detections: {},
+        },
+      ];
+
+      const csv = SdkRuntimeService.formatResultsCsv(results);
+      const lines = csv.split('\n');
+      // prompt is wrapped in quotes so commas don't break CSV parsing
+      expect(lines[1]).toBe('"hello, world, test","allow","benign","false","s1","r1"');
+    });
+
+    it('returns header only for empty results array', () => {
+      const csv = SdkRuntimeService.formatResultsCsv([]);
+      expect(csv).toBe('prompt,action,category,triggered,scan_id,report_id');
     });
   });
 });

--- a/tests/unit/audit/report.spec.ts
+++ b/tests/unit/audit/report.spec.ts
@@ -61,6 +61,113 @@ describe('buildAuditReportJson', () => {
     const json = buildAuditReportJson(result);
     expect(json.topics).toEqual([]);
   });
+
+  it('preserves all zero metrics', () => {
+    const zeroMetrics = mockMetrics({
+      truePositives: 0,
+      trueNegatives: 0,
+      falsePositives: 0,
+      falseNegatives: 0,
+      truePositiveRate: 0,
+      trueNegativeRate: 0,
+      accuracy: 0,
+      coverage: 0,
+      f1Score: 0,
+    });
+    const result = makeAuditResult({
+      compositeMetrics: zeroMetrics,
+      topics: [
+        {
+          topic: {
+            topicId: 't1',
+            topicName: 'Empty',
+            action: 'block',
+            description: 'No data',
+            examples: [],
+          },
+          testResults: [],
+          metrics: zeroMetrics,
+        },
+      ],
+    });
+    const json = buildAuditReportJson(result);
+    expect(json.compositeMetrics.coverage).toBe(0);
+    expect(json.compositeMetrics.accuracy).toBe(0);
+    expect(json.compositeMetrics.tpr).toBe(0);
+    expect(json.compositeMetrics.tnr).toBe(0);
+    expect(json.compositeMetrics.f1).toBe(0);
+    expect(json.topics[0].metrics.tp).toBe(0);
+    expect(json.topics[0].metrics.tn).toBe(0);
+    expect(json.topics[0].metrics.fp).toBe(0);
+    expect(json.topics[0].metrics.fn).toBe(0);
+  });
+
+  it('preserves conflict details including evidence', () => {
+    const result = makeAuditResult({
+      conflicts: [
+        {
+          topicA: 'Alpha',
+          topicB: 'Beta',
+          description: 'overlapping categories',
+          evidence: ['prompt A', 'prompt B', 'prompt C'],
+        },
+        {
+          topicA: 'Gamma',
+          topicB: 'Delta',
+          description: 'second conflict',
+          evidence: [],
+        },
+      ],
+    });
+    const json = buildAuditReportJson(result);
+    expect(json.conflicts).toHaveLength(2);
+    expect(json.conflicts[0].topicA).toBe('Alpha');
+    expect(json.conflicts[0].evidence).toEqual(['prompt A', 'prompt B', 'prompt C']);
+    expect(json.conflicts[1].evidence).toEqual([]);
+  });
+
+  it('maps testCount from testResults length', () => {
+    const result = makeAuditResult({
+      topics: [
+        {
+          topic: {
+            topicId: 't1',
+            topicName: 'WithTests',
+            action: 'block',
+            description: 'desc',
+            examples: [],
+          },
+          testResults: [
+            {
+              testCase: { prompt: 'p1', expectedTriggered: true, category: 'direct' },
+              actualTriggered: true,
+              scanAction: 'block',
+              scanId: 's1',
+              reportId: 'r1',
+              correct: true,
+            },
+            {
+              testCase: { prompt: 'p2', expectedTriggered: false, category: 'benign' },
+              actualTriggered: false,
+              scanAction: 'allow',
+              scanId: 's2',
+              reportId: 'r2',
+              correct: true,
+            },
+          ],
+          metrics: mockMetrics(),
+        },
+      ],
+    });
+    const json = buildAuditReportJson(result);
+    expect(json.topics[0].testCount).toBe(2);
+  });
+
+  it('includes description from topic in JSON output', () => {
+    const result = makeAuditResult();
+    const json = buildAuditReportJson(result);
+    expect(json.topics[0].description).toBe('Block weapons');
+  });
 });
 
 describe('buildAuditReportHtml', () => {
@@ -131,5 +238,67 @@ describe('buildAuditReportHtml', () => {
     const html = buildAuditReportHtml(result);
     expect(html).not.toContain('<script>xss');
     expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('escapes HTML entities in conflict descriptions and evidence', () => {
+    const result = makeAuditResult({
+      conflicts: [
+        {
+          topicA: '<b>Bold</b>',
+          topicB: 'Normal & Safe',
+          description: 'test <img onerror=alert(1)>',
+          evidence: ['prompt with "quotes" & <tags>'],
+        },
+      ],
+    });
+    const html = buildAuditReportHtml(result);
+    expect(html).not.toContain('<b>Bold</b>');
+    expect(html).toContain('&lt;b&gt;Bold&lt;/b&gt;');
+    expect(html).toContain('Normal &amp; Safe');
+    expect(html).toContain('&lt;img onerror=alert(1)&gt;');
+    expect(html).toContain('&amp; &lt;tags&gt;');
+  });
+
+  it('renders conflict section with multiple conflicts', () => {
+    const result = makeAuditResult({
+      conflicts: [
+        { topicA: 'A', topicB: 'B', description: 'first', evidence: ['e1'] },
+        { topicA: 'C', topicB: 'D', description: 'second', evidence: ['e2', 'e3'] },
+      ],
+    });
+    const html = buildAuditReportHtml(result);
+    expect(html).toContain('first');
+    expect(html).toContain('second');
+    expect(html).toContain('e2');
+    expect(html).toContain('e3');
+    // conflict count in summary
+    expect(html).toContain('>2<');
+  });
+
+  it('renders 0.0% for zero metrics', () => {
+    const result = makeAuditResult({
+      compositeMetrics: mockMetrics({
+        coverage: 0,
+        accuracy: 0,
+        truePositiveRate: 0,
+        trueNegativeRate: 0,
+      }),
+    });
+    const html = buildAuditReportHtml(result);
+    expect(html).toContain('0.0%');
+  });
+
+  it('renders empty topic table body when no topics', () => {
+    const result = makeAuditResult({ topics: [] });
+    const html = buildAuditReportHtml(result);
+    expect(html).toContain('<tbody></tbody>');
+    expect(html).toContain('>0<'); // topics count = 0
+  });
+
+  it('escapes HTML in profile name in title', () => {
+    const result = makeAuditResult({ profileName: 'test<script>' });
+    const html = buildAuditReportHtml(result);
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('test&lt;script&gt;');
   });
 });

--- a/tests/unit/audit/runner.spec.ts
+++ b/tests/unit/audit/runner.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { ManagementService, ScanResult } from '../../../src/airs/types.js';
+import type { ManagementService, ScanResult, ScanService } from '../../../src/airs/types.js';
 import type { AuditDependencies, AuditInput } from '../../../src/audit/runner.js';
 import { runAudit } from '../../../src/audit/runner.js';
 import type { AuditEvent, ProfileTopic } from '../../../src/audit/types.js';
@@ -168,6 +168,98 @@ describe('runAudit', () => {
       );
       // category=benign means allow topic matched → actualTriggered=true
       expect(positiveTest?.actualTriggered).toBe(true);
+    }
+  });
+
+  it('yields correct event sequence for single topic', async () => {
+    const deps: AuditDependencies = {
+      llm: createMockLlm(),
+      management: createMockManagement([blockTopic]),
+      scanner: createMockScanService(),
+    };
+    const events = await collectEvents({ profileName: 'test' }, deps);
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      'topics:loaded',
+      'tests:generated',
+      'scan:progress',
+      'evaluate:complete',
+      'audit:complete',
+    ]);
+  });
+
+  it('yields correct event order for multi-topic audit', async () => {
+    const thirdTopic: ProfileTopic = {
+      topicId: 't3',
+      topicName: 'Drugs',
+      action: 'block',
+      description: 'Block drug content',
+      examples: ['how to make meth'],
+    };
+    const deps: AuditDependencies = {
+      llm: createMockLlm(),
+      management: createMockManagement([blockTopic, allowTopic, thirdTopic]),
+      scanner: createMockScanService(),
+    };
+    const events = await collectEvents({ profileName: 'test' }, deps);
+    const types = events.map((e) => e.type);
+    // topics:loaded, then tests:generated per topic, then scan:progress, evaluate, audit
+    expect(types[0]).toBe('topics:loaded');
+    expect(types[1]).toBe('tests:generated');
+    expect(types[2]).toBe('tests:generated');
+    expect(types[3]).toBe('tests:generated');
+    expect(types[4]).toBe('scan:progress');
+    expect(types[5]).toBe('evaluate:complete');
+    expect(types[6]).toBe('audit:complete');
+    expect(events.filter((e) => e.type === 'tests:generated')).toHaveLength(3);
+  });
+
+  it('propagates error from scan service failure', async () => {
+    const failingScanner: ScanService = {
+      scan: async () => {
+        throw new Error('AIRS API unavailable');
+      },
+      scanBatch: async () => {
+        throw new Error('AIRS API unavailable');
+      },
+    };
+    const deps: AuditDependencies = {
+      llm: createMockLlm(),
+      management: createMockManagement([blockTopic]),
+      scanner: failingScanner,
+    };
+    await expect(collectEvents({ profileName: 'test' }, deps)).rejects.toThrow(
+      'AIRS API unavailable',
+    );
+  });
+
+  it('propagates error from LLM test generation failure', async () => {
+    const failingLlm = {
+      ...createMockLlm(),
+      generateTests: async () => {
+        throw new Error('LLM rate limited');
+      },
+    };
+    const deps: AuditDependencies = {
+      llm: failingLlm,
+      management: createMockManagement([blockTopic]),
+      scanner: createMockScanService(),
+    };
+    await expect(collectEvents({ profileName: 'test' }, deps)).rejects.toThrow('LLM rate limited');
+  });
+
+  it('scan:progress reports correct total across multiple topics', async () => {
+    const deps: AuditDependencies = {
+      llm: createMockLlm(),
+      management: createMockManagement([blockTopic, allowTopic]),
+      scanner: createMockScanService(),
+    };
+    const events = await collectEvents({ profileName: 'test' }, deps);
+    const progress = events.find((e) => e.type === 'scan:progress');
+    if (progress?.type === 'scan:progress') {
+      // 2 topics × (1 positive + 1 negative) = 4 tests total
+      expect(progress.completed).toBe(4);
+      expect(progress.total).toBe(4);
     }
   });
 


### PR DESCRIPTION
## Summary
- **runtime.spec.ts** (+6 tests): empty batch, batch boundaries, mixed poll statuses, CSV escaping
- **audit/report.spec.ts** (+8 tests): zero metrics, conflict details, HTML entity escaping, empty results
- **audit/runner.spec.ts** (+5 tests): single/multi-topic event order, error propagation from scan/LLM

402 → 422 tests total

Fixes #93

## Test plan
- [x] All 422 tests pass
- [x] Lint passes
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)