### PR TITLE
docs: document AIRS platform constraints and coverage expectations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ tests/
 - AIRS rejects empty `topic-list` entries — only include entries with topics (no empty opposite-action entry)
 - Guardrail-level `action` must always be `'block'` to enforce violations
 - Topics can't be deleted while referenced by any profile revision
+- **Platform ceilings**: Block-intent topics in high-sensitivity domains (explosives, weapons) trigger built-in AIRS safety that overrides custom definitions (0% TNR). Allow-intent topics use broad semantic matching — exclusion clauses increase FP; shorter descriptions outperform longer ones. Typical allow-intent ceiling: 40–70% coverage.
 
 ### Runtime Scanning (`src/airs/runtime.ts`)
 - `SdkRuntimeService` wraps SDK `Scanner` for sync and async scanning

--- a/docs/features/guardrail-generation.md
+++ b/docs/features/guardrail-generation.md
@@ -38,6 +38,42 @@ daystrom generate \
 - **Topic name lock**: After iteration 1, only the description and examples are refined — the name stays fixed
 - **Test composition**: Iteration 2+ carries forward failed tests and adds regression checks alongside fresh LLM-generated tests
 
+## Platform Constraints
+
+Achievable coverage depends on the topic domain and intent. AIRS has platform-level behaviors that limit what custom topic guardrails can accomplish.
+
+### Block-Intent on High-Sensitivity Topics
+
+Certain topic domains (explosives/weapons, CSAM, etc.) trigger AIRS built-in safety layers that **override custom topic definitions entirely**:
+
+- These topics achieve 100% TPR but **0% TNR** — the guardrail blocks ALL content, including completely unrelated prompts
+- Description refinement, exclusion clauses, and example tuning have zero observable effect
+- The built-in safety layer appears to key off the topic name/domain, not the description
+
+!!! warning "Recommendation"
+    Do not create custom block-intent topics for content that AIRS already handles via built-in safety. Use the default AIRS security profiles instead.
+
+### Allow-Intent Matching Behavior
+
+Allow-intent matching uses **broad semantic similarity**, not logical constraint evaluation:
+
+- Exclusion clauses ("not X", "excludes Y") do not work — they often **increase** false positives by adding semantic overlap with the excluded domain
+- Shorter, simpler descriptions (under 100 characters) consistently outperform longer, more specific ones
+- Typical achievable coverage for allow-intent topics: **40–70%** depending on topic breadth
+- Best results usually come from the first few iterations; extended refinement often degrades coverage
+
+### Description Truncation
+
+AIRS enforces hard limits on topic definitions. Descriptions exceeding 250 characters are silently truncated by `clampTopic()`, which can strip the positive definition while preserving only exclusion clauses — further degrading performance.
+
+| Constraint | Limit |
+|-----------|-------|
+| Topic name | 100 characters |
+| Description | 250 characters |
+| Each example | 250 characters |
+| Max examples | 5 |
+| Combined (description + examples) | 1000 characters |
+
 ## Related
 
 - [Core Loop Architecture](../architecture/core-loop.md) — detailed loop state machine

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -42,6 +42,9 @@ daystrom generate \
 
 The loop generates a topic, deploys it, scans test prompts, evaluates metrics, and refines until coverage reaches the target. [Full guardrail docs](../features/guardrail-generation.md)
 
+!!! note "Coverage expectations"
+    Achievable coverage depends on the topic domain and intent. Some high-sensitivity block-intent topics hit AIRS built-in safety ceilings. Allow-intent topics typically reach 40–70% coverage. See [Platform Constraints](../features/guardrail-generation.md#platform-constraints) for details.
+
 ---
 
 ## AI Red Teaming


### PR DESCRIPTION
## Summary
- Add "Platform Constraints" section to guardrail-generation.md covering block-intent ceilings, allow-intent matching behavior, and description truncation limits
- Add coverage expectations note to quick-start.md
- Add platform ceilings bullet to CLAUDE.md AIRS Integration section

Fixes #99

## Test plan
- [x] Lint passes
- [x] Type check passes
- [x] All 422 tests pass
- [x] Docs-only — no source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)