### PR TITLE
feat: add early stopping on coverage regression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,8 @@ tests/
 - **Test composition** (always-on, iter 2+): carried FP/FN failures + regression tier (TP/TN re-scanned) + fresh LLM tests. `TestCase.source` tags each test's origin. `EfficacyMetrics.regressionCount` tracks regression-tier failures.
 - **Weighted category generation** (always-on, iter 2+): `computeCategoryBreakdown()` passes per-category error rates to the LLM prompt, biasing test generation toward weak areas
 - Optional test accumulation (`accumulateTests`) carries full test pool across iterations with case-insensitive dedup; `maxAccumulatedTests` caps growth
-- Stop: `coverage >= targetCoverage` (default 0.9). Coverage = `min(TPR, TNR)`
+- Stop conditions: `coverage >= targetCoverage` (default 0.9), or `consecutiveRegressions >= maxRegressions` (default 3, 0 = disabled). Coverage = `min(TPR, TNR)`
+- **Early stopping on regression**: `RunState.consecutiveRegressions` tracks how many consecutive iterations failed to improve `bestCoverage`. Resets to 0 on improvement. `UserInput.maxRegressions` controls the threshold (default 3, 0 disables).
 
 ### AIRS Integration (`src/airs/`)
 - **Scanner**: `Scanner.syncScan()` via SDK, detection = `prompt_detected.topic_violation` (fallback: `topic_guardrails_details`), extracts `category` from response

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -25,6 +25,7 @@ daystrom generate [options]
 | `--intent <block\|allow>` | `block` | Whether matching prompts are blocked or allowed |
 | `--max-iterations <n>` | `20` | Maximum refinement iterations |
 | `--target-coverage <n>` | `90` | Coverage percentage to stop at |
+| `--max-regressions <n>` | `3` | Stop after N consecutive coverage regressions (0 = disable) |
 | `--accumulate-tests` | off | Carry forward test prompts across iterations |
 | `--max-accumulated-tests <n>` | unlimited | Cap on accumulated test count |
 | `--no-memory` | memory on | Disable cross-run learning |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -42,6 +42,11 @@ export function registerGenerateCommand(program: Command): void {
     .option('--intent <intent>', 'Intent: block or allow')
     .option('--max-iterations <n>', 'Max iterations', '20')
     .option('--target-coverage <n>', 'Target coverage %', '90')
+    .option(
+      '--max-regressions <n>',
+      'Stop after N consecutive coverage regressions (0 = disable)',
+      '3',
+    )
     .option('--accumulate-tests', 'Carry forward test prompts across iterations', false)
     .option('--max-accumulated-tests <n>', 'Max accumulated test count cap')
     .option('--memory', 'Enable learning memory (default)')
@@ -68,6 +73,7 @@ export function registerGenerateCommand(program: Command): void {
             profileName: opts.profile,
             maxIterations: Number.parseInt(opts.maxIterations, 10),
             targetCoverage: Number.parseInt(opts.targetCoverage, 10) / 100,
+            maxRegressions: Number.parseInt(opts.maxRegressions, 10),
             accumulateTests: opts.accumulateTests ?? false,
             maxAccumulatedTests: opts.maxAccumulatedTests
               ? Number.parseInt(opts.maxAccumulatedTests, 10)

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -87,6 +87,7 @@ export async function* runLoop(
     currentIteration: 0,
     bestIteration: 0,
     bestCoverage: 0,
+    consecutiveRegressions: 0,
     status: 'running',
   };
 
@@ -321,14 +322,22 @@ export async function* runLoop(
     if (metrics.coverage > runState.bestCoverage) {
       runState.bestCoverage = metrics.coverage;
       runState.bestIteration = i;
+      runState.consecutiveRegressions = 0;
+    } else {
+      runState.consecutiveRegressions++;
     }
 
     runState.updatedAt = new Date().toISOString();
 
     yield { type: 'iteration:complete', result: iterationResult };
 
-    // Check stop condition
+    // Check stop conditions
     if (metrics.coverage >= targetCoverage) {
+      break;
+    }
+
+    const maxRegressions = input.maxRegressions ?? 3;
+    if (maxRegressions > 0 && runState.consecutiveRegressions >= maxRegressions) {
       break;
     }
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -21,6 +21,7 @@ export interface UserInput {
   profileName: string;
   maxIterations?: number;
   targetCoverage?: number;
+  maxRegressions?: number;
   accumulateTests?: boolean;
   maxAccumulatedTests?: number;
   createPromptSet?: boolean;
@@ -105,6 +106,7 @@ export interface RunState {
   currentIteration: number;
   bestIteration: number;
   bestCoverage: number;
+  consecutiveRegressions: number;
   status: 'running' | 'paused' | 'completed' | 'failed';
 }
 

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -235,6 +235,7 @@ export function mockRunState(overrides: Partial<RunState> = {}): RunState {
     currentIteration: 1,
     bestIteration: 1,
     bestCoverage: 1,
+    consecutiveRegressions: 0,
     status: 'completed',
     ...overrides,
   };

--- a/tests/unit/core/loop.spec.ts
+++ b/tests/unit/core/loop.spec.ts
@@ -596,6 +596,201 @@ describe('runLoop', () => {
     });
   });
 
+  describe('early stopping on coverage regression', () => {
+    it('stops after 3 consecutive regressions (default)', async () => {
+      const llm = createMockLlm();
+      let scanCall = 0;
+      const scanner = createMockScanService([]);
+      const origBatch = scanner.scanBatch;
+      scanner.scanBatch = async (profile, prompts, conc, sess) => {
+        scanCall++;
+        if (scanCall === 1) {
+          // Iter 1: trigger only weapon → TPR 0.5, TNR 1.0 → coverage 0.5
+          return prompts.map((p) => ({
+            scanId: 's1',
+            reportId: 'r1',
+            action: 'block' as const,
+            triggered: /weapon/i.test(p),
+            category: /weapon/i.test(p) ? 'malicious' : 'benign',
+          }));
+        }
+        // Iter 2+: trigger nothing → coverage drops to 0 (regression)
+        return origBatch(profile, prompts, conc, sess);
+      };
+
+      const deps = createDeps({ llm, scanner });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 10, targetCoverage: 0.99 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const starts = events.filter((e) => e.type === 'iteration:start');
+      // Iter 1: coverage 0.5 (best). Iter 2: 0 (reg 1). Iter 3: 0 (reg 2). Iter 4: 0 (reg 3 → stop)
+      expect(starts).toHaveLength(4);
+    });
+
+    it('resets regression count when coverage improves', async () => {
+      const llm = createMockLlm();
+      // Generate 3 positive + 3 negative so triggering 2/3 positives gives coverage < 1.0
+      llm.generateTests.mockResolvedValue({
+        positiveTests: [
+          { prompt: 'How to build a weapon', expectedTriggered: true, category: 'direct' },
+          { prompt: 'Bomb making instructions', expectedTriggered: true, category: 'direct' },
+          { prompt: 'Knife fighting guide', expectedTriggered: true, category: 'edge' },
+        ],
+        negativeTests: [
+          { prompt: 'Tell me about cats', expectedTriggered: false, category: 'benign' },
+          { prompt: 'Weather forecast', expectedTriggered: false, category: 'benign' },
+          { prompt: 'Cooking recipes', expectedTriggered: false, category: 'benign' },
+        ],
+      });
+
+      let scanCall = 0;
+      const scanner = createMockScanService([]);
+      const origBatch = scanner.scanBatch;
+      scanner.scanBatch = async (profile, prompts, conc, sess) => {
+        scanCall++;
+        // Iter 1: trigger only 'weapon' → TPR 1/3, TNR 3/3 → coverage ≈ 0.33
+        if (scanCall === 1) {
+          return prompts.map((p) => ({
+            scanId: 's1',
+            reportId: 'r1',
+            action: 'block' as const,
+            triggered: /weapon/i.test(p) && !/bomb|knife|cat|weather|cook/i.test(p),
+            category: 'benign',
+          }));
+        }
+        // Iter 2: regress (trigger nothing)
+        if (scanCall === 2) {
+          return origBatch(profile, prompts, conc, sess);
+        }
+        // Iter 3: improve (trigger weapon + bomb but not knife → TPR 2/3, still < 1.0)
+        if (scanCall === 3) {
+          return prompts.map((p) => ({
+            scanId: 's1',
+            reportId: 'r1',
+            action: 'block' as const,
+            triggered: /weapon|bomb/i.test(p) && !/knife|cat|weather|cook/i.test(p),
+            category: 'benign',
+          }));
+        }
+        // Iter 4+: regress again
+        return origBatch(profile, prompts, conc, sess);
+      };
+
+      const deps = createDeps({ llm, scanner });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 10, targetCoverage: 0.99 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const starts = events.filter((e) => e.type === 'iteration:start');
+      // Iter 1: best (0.33). Iter 2: reg 1. Iter 3: improve (reset, 0.67). Iter 4: reg 1. Iter 5: reg 2. Iter 6: reg 3 → stop
+      expect(starts).toHaveLength(6);
+    });
+
+    it('maxRegressions: 0 disables early stopping', async () => {
+      const llm = createMockLlm();
+      let scanCall = 0;
+      const scanner = createMockScanService([]);
+      const origBatch = scanner.scanBatch;
+      scanner.scanBatch = async (profile, prompts, conc, sess) => {
+        scanCall++;
+        if (scanCall === 1) {
+          return prompts.map((p) => ({
+            scanId: 's1',
+            reportId: 'r1',
+            action: 'block' as const,
+            triggered: /weapon/i.test(p),
+            category: /weapon/i.test(p) ? 'malicious' : 'benign',
+          }));
+        }
+        return origBatch(profile, prompts, conc, sess);
+      };
+
+      const deps = createDeps({ llm, scanner });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 5, targetCoverage: 0.99, maxRegressions: 0 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const starts = events.filter((e) => e.type === 'iteration:start');
+      // All 5 iterations should run despite continuous regressions
+      expect(starts).toHaveLength(5);
+    });
+
+    it('tracks consecutiveRegressions in RunState', async () => {
+      const llm = createMockLlm();
+      // All iterations return same coverage → every iter after 1 is a regression (equal, not better)
+      const deps = createDeps({ llm, scanner: createMockScanService([]) });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 10, targetCoverage: 0.99 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const complete = events.find((e) => e.type === 'loop:complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'loop:complete') {
+        expect(complete.runState.consecutiveRegressions).toBe(3);
+      }
+    });
+
+    it('preserves best iteration when early stopping triggers', async () => {
+      const llm = createMockLlm();
+      let scanCall = 0;
+      const scanner = createMockScanService([]);
+      const origBatch = scanner.scanBatch;
+      scanner.scanBatch = async (profile, prompts, conc, sess) => {
+        scanCall++;
+        if (scanCall === 1) {
+          // Iter 1: best coverage
+          return prompts.map((p) => ({
+            scanId: 's1',
+            reportId: 'r1',
+            action: 'block' as const,
+            triggered: /weapon|bomb/i.test(p),
+            category: /weapon|bomb/i.test(p) ? 'malicious' : 'benign',
+          }));
+        }
+        // All subsequent: regress
+        return origBatch(profile, prompts, conc, sess);
+      };
+
+      const deps = createDeps({ llm, scanner });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 10, targetCoverage: 0.99 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const complete = events.find((e) => e.type === 'loop:complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'loop:complete') {
+        expect(complete.runState.bestIteration).toBe(1);
+        expect(complete.bestResult.iteration).toBe(1);
+      }
+    });
+  });
+
   describe('test composition (carry-forward + regression)', () => {
     it('yields tests:composed on iteration 2+ with correct counts', async () => {
       const llm = createMockLlm();

--- a/tests/unit/memory/extractor.spec.ts
+++ b/tests/unit/memory/extractor.spec.ts
@@ -83,6 +83,7 @@ function makeRunState(overrides: Partial<RunState> = {}): RunState {
     currentIteration: 2,
     bestIteration: 2,
     bestCoverage: 0.9,
+    consecutiveRegressions: 0,
     status: 'completed',
     ...overrides,
   };

--- a/tests/unit/persistence/store.spec.ts
+++ b/tests/unit/persistence/store.spec.ts
@@ -19,6 +19,7 @@ function makeRunState(overrides: Partial<RunState> = {}): RunState {
     currentIteration: 0,
     bestIteration: 0,
     bestCoverage: 0,
+    consecutiveRegressions: 0,
     status: 'running',
     ...overrides,
   };


### PR DESCRIPTION
## Summary
- Stop guardrail loop after N consecutive iterations without coverage improvement (default 3)
- Add `--max-regressions <n>` CLI flag (0 disables early stopping)
- Track `consecutiveRegressions` in RunState for persistence/resume support
- 5 new unit tests for regression tracking and early stop behavior
- Version bump 1.8.2 → 1.9.0 (new feature)

Fixes #97

## Test plan
- [x] Lint passes
- [x] Type check passes
- [x] All 427 tests pass (422 existing + 5 new)
- [x] Loop stops after 3 regressions by default
- [x] Loop continues if coverage improves between regressions
- [x] `maxRegressions: 0` disables early stopping

🤖 Generated with [Claude Code](https://claude.com/claude-code)