### PR TITLE
feat: teach improveTopic that shorter descriptions outperform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,8 @@ tests/
 - All 4 calls use `withStructuredOutput(ZodSchema)` — 3 retries on parse failure
 - Memory injected via `{memorySection}` template variable
 - `clampTopic()` enforces AIRS constraints post-LLM (not Zod) — drops examples, trims description
+- `improveTopic()` accepts optional `bestContext` param `{ bestCoverage, bestIteration, bestTopic? }` — injects regression warnings into the prompt when coverage drops below the best iteration, and always shows best-iteration context
+- Improve-topic system prompt includes CRITICAL PLATFORM CONSTRAINT section warning against exclusion clauses and favoring shorter descriptions
 
 ### Memory System (`src/memory/`)
 - File-based at `~/.daystrom/memory/{category}.json`

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -41,6 +41,7 @@ export interface LlmService {
     iteration: number,
     targetCoverage: number,
     intent: string,
+    bestContext?: { bestCoverage: number; bestIteration: number; bestTopic?: CustomTopic },
   ): Promise<CustomTopic>;
 }
 
@@ -120,6 +121,11 @@ export async function* runLoop(
         i,
         targetCoverage,
         input.intent,
+        {
+          bestCoverage: runState.bestCoverage,
+          bestIteration: runState.bestIteration,
+          bestTopic: runState.iterations[runState.bestIteration - 1]?.topic,
+        },
       );
       // Force the name to stay consistent across iterations
       currentTopic = { ...currentTopic, name: lockedName };

--- a/src/llm/prompts/improve-topic.ts
+++ b/src/llm/prompts/improve-topic.ts
@@ -11,6 +11,15 @@ Constraints (MUST be respected):
 - Examples: 2-5 examples, each max 250 characters. You may vary the count between 2-5 to find optimal efficacy.
 - Combined total (name + description + all examples): max 1000 characters
 
+CRITICAL PLATFORM CONSTRAINT:
+- The matching engine uses semantic similarity, NOT logical constraint evaluation.
+- Exclusion clauses ("not X", "no Y", "excludes Z") are IGNORED by the platform and often INCREASE false positives by adding semantic overlap with the excluded domain.
+- Negation language does not work. "Not meal plans" makes the system MORE likely to match meal plans.
+- SHORTER descriptions (under 100 chars) consistently outperform longer ones with exclusions.
+- NEVER add exclusion clauses to the description.
+- Instead of listing what the topic is NOT, make the positive definition more precise.
+- If the current description has exclusion clauses and TNR is poor, try REMOVING them entirely.
+
 Focus on improving the description and examples:
 - The description carries the most weight in AIRS topic matching. Invest in making it precise.
 - Making the description more precise to reduce false positives
@@ -46,6 +55,9 @@ Performance (iteration {iteration}):
 - Coverage: {coverage} (target: {targetCoverage})
 - TPR: {tpr}, TNR: {tnr}
 - Accuracy: {accuracy}
+
+Best so far: {bestCoverage} coverage at iteration {bestIteration}
+{bestTopicSection}
 
 Analysis Summary: {analysisSummary}
 

--- a/src/llm/service.ts
+++ b/src/llm/service.ts
@@ -209,12 +209,29 @@ export class LangChainLlmService implements LlmService {
     iteration: number,
     targetCoverage: number,
     intent: string,
+    bestContext?: { bestCoverage: number; bestIteration: number; bestTopic?: CustomTopic },
   ): Promise<CustomTopic> {
     const structured = this.model.withStructuredOutput(CustomTopicSchema);
     const chain = improveTopicPrompt.pipe(structured);
 
     const fps = results.filter((r) => !r.testCase.expectedTriggered && r.actualTriggered);
     const fns = results.filter((r) => r.testCase.expectedTriggered && !r.actualTriggered);
+
+    // Build best-context template variables
+    const bestCoverage = bestContext
+      ? `${(bestContext.bestCoverage * 100).toFixed(1)}%`
+      : `${(metrics.coverage * 100).toFixed(1)}%`;
+    const bestIteration = bestContext ? bestContext.bestIteration : iteration;
+
+    let bestTopicSection = '';
+    if (bestContext?.bestTopic && metrics.coverage < bestContext.bestCoverage) {
+      const bt = bestContext.bestTopic;
+      bestTopicSection = `REGRESSION WARNING: Coverage has dropped from ${(bestContext.bestCoverage * 100).toFixed(1)}% (iteration ${bestContext.bestIteration}) to ${(metrics.coverage * 100).toFixed(1)}%.
+The best-performing definition was:
+  Description: ${bt.description}
+  Examples: ${bt.examples.join(', ')}
+Consider reverting toward this simpler definition rather than adding more specificity.`;
+    }
 
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       try {
@@ -230,6 +247,9 @@ export class LangChainLlmService implements LlmService {
           tpr: `${(metrics.truePositiveRate * 100).toFixed(1)}%`,
           tnr: `${(metrics.trueNegativeRate * 100).toFixed(1)}%`,
           accuracy: `${(metrics.accuracy * 100).toFixed(1)}%`,
+          bestCoverage,
+          bestIteration,
+          bestTopicSection,
           analysisSummary: analysis.summary,
           fpPatterns: analysis.falsePositivePatterns.join('; ') || 'None',
           fnPatterns: analysis.falseNegativePatterns.join('; ') || 'None',

--- a/tests/unit/core/loop.spec.ts
+++ b/tests/unit/core/loop.spec.ts
@@ -355,6 +355,7 @@ describe('runLoop', () => {
       2,
       0.9,
       'block',
+      expect.anything(),
     );
   });
 
@@ -383,6 +384,7 @@ describe('runLoop', () => {
       2,
       0.9,
       'allow',
+      expect.anything(),
     );
   });
 

--- a/tests/unit/llm/prompts.spec.ts
+++ b/tests/unit/llm/prompts.spec.ts
@@ -63,5 +63,129 @@ describe('prompt templates', () => {
     expect(vars).toContain('iteration');
     expect(vars).toContain('intent');
     expect(vars).toContain('memorySection');
+    expect(vars).toContain('bestCoverage');
+    expect(vars).toContain('bestIteration');
+    expect(vars).toContain('bestTopicSection');
+  });
+
+  it('improveTopicPrompt system message includes platform constraint warning', async () => {
+    const messages = await improveTopicPrompt.formatMessages({
+      currentName: 'Test',
+      currentDescription: 'Test desc',
+      currentExamples: 'ex1, ex2',
+      exampleCount: 2,
+      iteration: 2,
+      coverage: '50.0%',
+      targetCoverage: '90.0%',
+      tpr: '50.0%',
+      tnr: '50.0%',
+      accuracy: '50.0%',
+      bestCoverage: '60.0%',
+      bestIteration: 1,
+      bestTopicSection: '',
+      analysisSummary: 'summary',
+      fpPatterns: 'None',
+      fnPatterns: 'None',
+      specificFPs: 'None',
+      specificFNs: 'None',
+      suggestions: 'suggestion',
+      intent: 'block',
+      memorySection: '',
+    });
+    const systemContent = messages[0].content as string;
+    expect(systemContent).toContain('CRITICAL PLATFORM CONSTRAINT');
+    expect(systemContent).toContain('Exclusion clauses');
+    expect(systemContent).toContain('SHORTER descriptions');
+  });
+
+  it('improveTopicPrompt includes best context in human message', async () => {
+    const messages = await improveTopicPrompt.formatMessages({
+      currentName: 'Test',
+      currentDescription: 'Test desc',
+      currentExamples: 'ex1, ex2',
+      exampleCount: 2,
+      iteration: 3,
+      coverage: '50.0%',
+      targetCoverage: '90.0%',
+      tpr: '50.0%',
+      tnr: '50.0%',
+      accuracy: '50.0%',
+      bestCoverage: '70.0%',
+      bestIteration: 2,
+      bestTopicSection: '',
+      analysisSummary: 'summary',
+      fpPatterns: 'None',
+      fnPatterns: 'None',
+      specificFPs: 'None',
+      specificFNs: 'None',
+      suggestions: 'suggestion',
+      intent: 'block',
+      memorySection: '',
+    });
+    const humanContent = messages[1].content as string;
+    expect(humanContent).toContain('Best so far: 70.0% coverage at iteration 2');
+  });
+
+  it('improveTopicPrompt includes regression warning when coverage regresses', async () => {
+    const regressionWarning = `REGRESSION WARNING: Coverage has dropped from 70.0% (iteration 2) to 50.0%.
+The best-performing definition was:
+  Description: Best desc
+  Examples: ex1, ex2
+Consider reverting toward this simpler definition rather than adding more specificity.`;
+
+    const messages = await improveTopicPrompt.formatMessages({
+      currentName: 'Test',
+      currentDescription: 'Test desc',
+      currentExamples: 'ex1, ex2',
+      exampleCount: 2,
+      iteration: 3,
+      coverage: '50.0%',
+      targetCoverage: '90.0%',
+      tpr: '50.0%',
+      tnr: '50.0%',
+      accuracy: '50.0%',
+      bestCoverage: '70.0%',
+      bestIteration: 2,
+      bestTopicSection: regressionWarning,
+      analysisSummary: 'summary',
+      fpPatterns: 'None',
+      fnPatterns: 'None',
+      specificFPs: 'None',
+      specificFNs: 'None',
+      suggestions: 'suggestion',
+      intent: 'block',
+      memorySection: '',
+    });
+    const humanContent = messages[1].content as string;
+    expect(humanContent).toContain('REGRESSION WARNING');
+    expect(humanContent).toContain('Best desc');
+  });
+
+  it('improveTopicPrompt omits regression warning when coverage is at or above best', async () => {
+    const messages = await improveTopicPrompt.formatMessages({
+      currentName: 'Test',
+      currentDescription: 'Test desc',
+      currentExamples: 'ex1, ex2',
+      exampleCount: 2,
+      iteration: 3,
+      coverage: '70.0%',
+      targetCoverage: '90.0%',
+      tpr: '70.0%',
+      tnr: '70.0%',
+      accuracy: '70.0%',
+      bestCoverage: '70.0%',
+      bestIteration: 2,
+      bestTopicSection: '',
+      analysisSummary: 'summary',
+      fpPatterns: 'None',
+      fnPatterns: 'None',
+      specificFPs: 'None',
+      specificFNs: 'None',
+      suggestions: 'suggestion',
+      intent: 'block',
+      memorySection: '',
+    });
+    const humanContent = messages[1].content as string;
+    expect(humanContent).not.toContain('REGRESSION WARNING');
   });
 });

--- a/tests/unit/llm/service.spec.ts
+++ b/tests/unit/llm/service.spec.ts
@@ -323,6 +323,58 @@ describe('LangChainLlmService', () => {
       const result = await service.improveTopic(validTopic, metrics, emptyAnalysis, [], 2, 0.9);
       expect(result.name).toBe('Weapons');
     });
+
+    it('accepts bestContext parameter without error', async () => {
+      const model = createMockModel(validTopic);
+      const service = new LangChainLlmService(model as BaseChatModel);
+      const bestContext = {
+        bestCoverage: 0.85,
+        bestIteration: 1,
+        bestTopic: {
+          name: 'Weapons',
+          description: 'Best performing description',
+          examples: ['ex1', 'ex2'],
+        },
+      };
+      const result = await service.improveTopic(
+        validTopic,
+        metrics,
+        analysis,
+        [],
+        3,
+        0.9,
+        'block',
+        bestContext,
+      );
+      expect(result.name).toBe('Weapons');
+    });
+
+    it('includes regression warning when coverage < bestCoverage', async () => {
+      const model = createMockModel(validTopic);
+      const service = new LangChainLlmService(model as BaseChatModel);
+      const lowMetrics = { ...metrics, coverage: 0.5 };
+      const bestContext = {
+        bestCoverage: 0.8,
+        bestIteration: 1,
+        bestTopic: {
+          name: 'Weapons',
+          description: 'Best desc',
+          examples: ['best ex1'],
+        },
+      };
+      // Should succeed — regression warning is injected into prompt but doesn't change output
+      const result = await service.improveTopic(
+        validTopic,
+        lowMetrics,
+        analysis,
+        [],
+        3,
+        0.9,
+        'block',
+        bestContext,
+      );
+      expect(result.name).toBe('Weapons');
+    });
   });
 
   describe('loadMemory', () => {


### PR DESCRIPTION
## Summary
- Add CRITICAL PLATFORM CONSTRAINT section to improve-topic system prompt warning against exclusion clauses, negation language, and favoring shorter descriptions
- Pass `bestContext` (bestCoverage, bestIteration, bestTopic) to `improveTopic()` so the LLM knows when it's regressing
- Show regression warning with the best-performing topic definition when current coverage < best
- 6 new tests for prompt construction and bestContext passthrough

Fixes #98

## Test plan
- [x] Lint passes
- [x] Type check passes
- [x] All 433 tests pass (427 existing + 6 new)
- [x] Prompt includes platform constraint warning
- [x] Regression warning shown only when coverage drops below best

🤖 Generated with [Claude Code](https://claude.com/claude-code)