### PR TITLE
feat: detect duplicate topic definitions across iterations

### DIFF
--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -183,6 +183,11 @@ export function registerGenerateCommand(program: Command): void {
               console.log('  ⚡ Topic simplified after consecutive regressions');
               renderTopic(event.topic);
               break;
+            case 'topic:duplicate':
+              console.log(
+                `  ⚠ Topic identical to iteration ${event.duplicateOfIteration} — skipping scan`,
+              );
+              break;
             case 'memory:extracted':
               renderMemoryExtracted(event.learningCount);
               break;

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -73,6 +73,20 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Check if a topic definition matches any previous iteration's topic. Returns the iteration number or null. */
+function findDuplicateIteration(topic: CustomTopic, iterations: IterationResult[]): number | null {
+  for (const iter of iterations) {
+    if (
+      iter.topic.description === topic.description &&
+      iter.topic.examples.length === topic.examples.length &&
+      iter.topic.examples.every((e, idx) => e === topic.examples[idx])
+    ) {
+      return iter.iteration;
+    }
+  }
+  return null;
+}
+
 /**
  * Main refinement loop — generates, deploys, tests, and iteratively improves a topic.
  * Yields typed {@link LoopEvent} discriminated unions at each stage.
@@ -138,6 +152,59 @@ export async function* runLoop(
       );
       // Force the name to stay consistent across iterations
       currentTopic = { ...currentTopic, name: lockedName };
+
+      // Skip scanning if topic is identical to a previous iteration
+      const dupIter = findDuplicateIteration(currentTopic, runState.iterations);
+      if (dupIter !== null) {
+        yield {
+          type: 'topic:duplicate' as const,
+          topic: currentTopic,
+          duplicateOfIteration: dupIter,
+        };
+        runState.consecutiveRegressions++;
+        runState.currentIteration = i;
+        runState.updatedAt = new Date().toISOString();
+
+        // Try simplification if threshold reached (same logic as end-of-iteration)
+        const simplifyThreshold = 2;
+        if (
+          runState.consecutiveRegressions >= simplifyThreshold &&
+          !runState.hasTriedSimplification &&
+          runState.bestIteration > 0
+        ) {
+          const bestResult = runState.iterations[runState.bestIteration - 1];
+          if (bestResult) {
+            currentTopic = await deps.llm.simplifyTopic(
+              currentTopic,
+              bestResult.topic,
+              bestResult.metrics,
+              bestResult.analysis,
+              input.intent,
+            );
+            currentTopic = { ...currentTopic, name: lockedName };
+            runState.hasTriedSimplification = true;
+            runState.consecutiveRegressions = 0;
+            yield { type: 'topic:simplified' as const, topic: currentTopic };
+
+            // If simplified topic is also a duplicate, don't reset — count it
+            const simpDupIter = findDuplicateIteration(currentTopic, runState.iterations);
+            if (simpDupIter !== null) {
+              yield {
+                type: 'topic:duplicate' as const,
+                topic: currentTopic,
+                duplicateOfIteration: simpDupIter,
+              };
+              runState.consecutiveRegressions++;
+            }
+          }
+        }
+
+        const maxRegressions = input.maxRegressions ?? 3;
+        if (maxRegressions > 0 && runState.consecutiveRegressions >= maxRegressions) {
+          break;
+        }
+        continue;
+      }
     }
 
     /* v8 ignore next */
@@ -373,6 +440,17 @@ export async function* runLoop(
         runState.hasTriedSimplification = true;
         runState.consecutiveRegressions = 0;
         yield { type: 'topic:simplified' as const, topic: currentTopic };
+
+        // Check if simplified topic is a duplicate of a previous iteration
+        const simpDupIter = findDuplicateIteration(currentTopic, runState.iterations);
+        if (simpDupIter !== null) {
+          yield {
+            type: 'topic:duplicate' as const,
+            topic: currentTopic,
+            duplicateOfIteration: simpDupIter,
+          };
+          runState.consecutiveRegressions++;
+        }
       }
     }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -135,4 +135,5 @@ export type LoopEvent =
   | { type: 'memory:loaded'; learningCount: number }
   | { type: 'memory:extracted'; learningCount: number }
   | { type: 'topic:simplified'; topic: CustomTopic }
+  | { type: 'topic:duplicate'; topic: CustomTopic; duplicateOfIteration: number }
   | { type: 'promptset:created'; promptSetId: string; promptSetName: string; promptCount: number };

--- a/tests/integration/loop.integration.spec.ts
+++ b/tests/integration/loop.integration.spec.ts
@@ -217,10 +217,18 @@ describe('Loop Integration', () => {
         falseNegativePatterns: [],
         suggestions: ['improve'],
       }),
-      improveTopic: async () => ({
+      improveTopic: async () => {
+        testCall++;
+        return {
+          name: 'Weapons Discussion',
+          description: `Improved weapons block v${testCall}`,
+          examples: [`weapon example improved ${testCall}`],
+        };
+      },
+      simplifyTopic: async () => ({
         name: 'Weapons Discussion',
-        description: 'Improved weapons block',
-        examples: ['weapon example improved'],
+        description: 'Weapons block simplified',
+        examples: ['weapon example'],
       }),
     };
 

--- a/tests/unit/core/loop.spec.ts
+++ b/tests/unit/core/loop.spec.ts
@@ -60,23 +60,29 @@ function createMockLlm() {
         falseNegativePatterns: [],
         suggestions: ['Keep current definition'],
       }),
-    improveTopic: vi
-      .fn<
-        (
-          topic: CustomTopic,
-          metrics: EfficacyMetrics,
-          analysis: AnalysisReport,
-          results: TestResult[],
-          iteration: number,
-          targetCoverage: number,
-          intent: string,
-        ) => Promise<CustomTopic>
-      >()
-      .mockResolvedValue({
-        name: 'Weapons Discussion v2',
-        description: 'Block all weapons-related conversations',
-        examples: ['How to make a weapon', 'Gun manufacturing', 'Ammunition sourcing'],
-      }),
+    improveTopic: (() => {
+      let improveCall = 0;
+      return vi
+        .fn<
+          (
+            topic: CustomTopic,
+            metrics: EfficacyMetrics,
+            analysis: AnalysisReport,
+            results: TestResult[],
+            iteration: number,
+            targetCoverage: number,
+            intent: string,
+          ) => Promise<CustomTopic>
+        >()
+        .mockImplementation(async () => {
+          improveCall++;
+          return {
+            name: `Weapons Discussion v${improveCall + 1}`,
+            description: `Block weapons-related conversations variant ${improveCall}`,
+            examples: ['How to make a weapon', 'Gun manufacturing', `Variant ${improveCall}`],
+          };
+        });
+    })(),
     simplifyTopic: vi
       .fn<
         (
@@ -993,6 +999,178 @@ describe('runLoop', () => {
         // Should eventually stop, not run all 20 iterations
         expect(complete.runState.iterations.length).toBeLessThan(20);
       }
+    });
+  });
+
+  describe('duplicate topic detection', () => {
+    it('skips scanning when improveTopic returns identical topic', async () => {
+      const llm = createMockLlm();
+      // improveTopic returns the same topic every time
+      llm.improveTopic.mockImplementation(async () => ({
+        name: 'Weapons Discussion',
+        description: 'Block conversations about weapons',
+        examples: ['How to make a weapon', 'Gun manufacturing'],
+      }));
+      const deps = createDeps({ llm, scanner: createMockScanService([/weapon/i]) });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 5, targetCoverage: 0.99 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const dupes = events.filter((e) => e.type === 'topic:duplicate');
+      // Iter 1 scans normally, iter 2+ should detect duplicate of iter 1
+      expect(dupes.length).toBeGreaterThanOrEqual(1);
+      if (dupes[0]?.type === 'topic:duplicate') {
+        expect(dupes[0].duplicateOfIteration).toBe(1);
+      }
+    });
+
+    it('increments consecutiveRegressions on duplicate', async () => {
+      const llm = createMockLlm();
+      // Always return same topic from improveTopic
+      llm.improveTopic.mockImplementation(async () => ({
+        name: 'Weapons Discussion',
+        description: 'Block conversations about weapons',
+        examples: ['How to make a weapon', 'Gun manufacturing'],
+      }));
+      const deps = createDeps({ llm, scanner: createMockScanService([/weapon/i]) });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 10, targetCoverage: 0.99 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const complete = events.find((e) => e.type === 'loop:complete');
+      expect(complete).toBeDefined();
+      if (complete?.type === 'loop:complete') {
+        expect(complete.runState.consecutiveRegressions).toBeGreaterThanOrEqual(3);
+      }
+    });
+
+    it('triggers early stopping when duplicates exhaust maxRegressions', async () => {
+      const llm = createMockLlm();
+      const dupTopic = {
+        name: 'Weapons Discussion',
+        description: 'Block conversations about weapons',
+        examples: ['How to make a weapon', 'Gun manufacturing'],
+      };
+      llm.improveTopic.mockImplementation(async () => ({ ...dupTopic }));
+      // Simplification also returns same topic → still a duplicate
+      llm.simplifyTopic.mockImplementation(async () => ({ ...dupTopic }));
+      const deps = createDeps({ llm, scanner: createMockScanService([/weapon/i]) });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 20, targetCoverage: 0.99, maxRegressions: 2 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const starts = events.filter((e) => e.type === 'iteration:start');
+      // Iter 1: scan, Iter 2: dup (reg 1), Iter 3: dup (reg 2 → simplify → dup, reg 1),
+      // Iter 4: dup (reg 2) → stop
+      expect(starts.length).toBeLessThanOrEqual(4);
+    });
+
+    it('does not flag topics with different descriptions as duplicates', async () => {
+      const llm = createMockLlm();
+      let improveCall = 0;
+      llm.improveTopic.mockImplementation(async () => {
+        improveCall++;
+        return {
+          name: 'Weapons Discussion',
+          description: `Variant ${improveCall}`,
+          examples: ['How to make a weapon', 'Gun manufacturing'],
+        };
+      });
+      const deps = createDeps({ llm, scanner: createMockScanService([]) });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 3, targetCoverage: 0.99 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const dupes = events.filter((e) => e.type === 'topic:duplicate');
+      expect(dupes).toHaveLength(0);
+    });
+
+    it('does not flag topics with different examples as duplicates', async () => {
+      const llm = createMockLlm();
+      let improveCall = 0;
+      llm.improveTopic.mockImplementation(async () => {
+        improveCall++;
+        return {
+          name: 'Weapons Discussion',
+          description: 'Block conversations about weapons',
+          examples: [`Example ${improveCall}`],
+        };
+      });
+      const deps = createDeps({ llm, scanner: createMockScanService([]) });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 3, targetCoverage: 0.99 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const dupes = events.filter((e) => e.type === 'topic:duplicate');
+      expect(dupes).toHaveLength(0);
+    });
+
+    it('detects duplicate after simplification', async () => {
+      const llm = createMockLlm();
+      // simplifyTopic returns the same topic as iteration 1
+      llm.simplifyTopic.mockImplementation(async () => ({
+        name: 'Weapons Discussion',
+        description: 'Block conversations about weapons',
+        examples: ['How to make a weapon', 'Gun manufacturing'],
+      }));
+
+      let scanCall = 0;
+      const scanner = createMockScanService([]);
+      const origBatch = scanner.scanBatch;
+      scanner.scanBatch = async (profile, prompts, conc, sess) => {
+        scanCall++;
+        if (scanCall === 1) {
+          return prompts.map((p) => ({
+            scanId: 's1',
+            reportId: 'r1',
+            action: 'block' as const,
+            triggered: /weapon/i.test(p),
+            category: /weapon/i.test(p) ? 'malicious' : 'benign',
+          }));
+        }
+        return origBatch(profile, prompts, conc, sess);
+      };
+
+      const deps = createDeps({ llm, scanner });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        { ...defaultInput, maxIterations: 10, targetCoverage: 0.99 },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const simplified = events.filter((e) => e.type === 'topic:simplified');
+      const dupes = events.filter((e) => e.type === 'topic:duplicate');
+      expect(simplified).toHaveLength(1);
+      // Simplified topic matches iter 1 → duplicate detected
+      expect(dupes.length).toBeGreaterThanOrEqual(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `findDuplicateIteration()` helper that compares description + examples against all prior iterations
- When duplicate detected after `improveTopic()`: yield `topic:duplicate` event, increment `consecutiveRegressions`, skip scanning
- When duplicate detected after `simplifyTopic()`: same handling, prevents counter reset
- Simplification still triggers within duplicate path when threshold reached
- Updated mock `improveTopic` to return unique topics per call (counter-based) to avoid false duplicate detection in existing tests

## Test plan
- [x] 449 tests pass (6 new: duplicate detection, early stopping, non-duplicate cases, post-simplification detection)
- [x] TypeScript compiles cleanly
- [x] Biome lint passes

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)