### PR TITLE
feat: improve simplification prompt to revert toward best

### DIFF
--- a/src/llm/prompts/simplify-topic.ts
+++ b/src/llm/prompts/simplify-topic.ts
@@ -3,51 +3,48 @@ import { ChatPromptTemplate } from '@langchain/core/prompts';
 export const simplifyTopicPrompt = ChatPromptTemplate.fromMessages([
   [
     'system',
-    `You are an expert at simplifying Prisma AIRS custom topic guardrails. Your goal is to produce a SHORTER, SIMPLER definition that performs better than the current over-refined one.
+    `You are an expert at simplifying Prisma AIRS custom topic guardrails. Your output should be the best-performing definition with at most minor wording adjustments. Do NOT add qualifiers, specificity, or new constraints.
 
 Constraints (MUST be respected):
 - Name: KEEP THE EXACT SAME NAME as the current definition. Do NOT rename.
-- Description: max 250 characters
-- Examples: 2-5 examples, each max 250 characters
+- Description: max 250 characters. Aim for UNDER 80 characters.
+- Examples: 2-3 examples, each max 250 characters
 - Combined total (name + description + all examples): max 1000 characters
 
-WHY SIMPLIFICATION WORKS:
-- AIRS uses semantic similarity matching, NOT logical constraint evaluation
-- Exclusion clauses ("not X", "excludes Y") are IGNORED and often INCREASE false positives
-- Shorter descriptions (under 100 chars) consistently outperform longer ones
-- Over-refinement across iterations typically DEGRADES coverage by adding noise
-- The best-performing definition was usually simpler than the current one
+CRITICAL RULES:
+- Start from the best-performing definition. Make minimal changes.
+- Do NOT add words like "single", "specific", "one", "only", "sole", "step-by-step"
+- Do NOT add exclusion clauses ("not X", "excludes Y") — they INCREASE false positives
+- SHORTER is ALWAYS better on this platform. Every word you add risks degrading performance.
+- If the best-performing definition already works, return it nearly unchanged.
 
-SIMPLIFICATION STRATEGY:
-1. Remove ALL exclusion/negation clauses from the description
-2. Aim for a description UNDER 100 characters — shorter is better
-3. Use 2-3 focused examples instead of 5 broad ones
-4. Revert toward the best-performing definition's style and language
-5. Use clear, direct, positive language — state what the topic IS, not what it ISN'T
-6. Prefer concrete nouns and verbs over abstract qualifiers
+GOOD vs BAD simplification:
+- GOOD: "Cooking recipes for specific dishes" (short, broad, 40 chars)
+- BAD: "A single cooking recipe for one specific dish with step-by-step instructions" (long, over-qualified, 76 chars)
+- GOOD: "Financial investment advice and strategies" (42 chars)
+- BAD: "Requests for personalized financial investment advice specifically about stock market strategies excluding general banking" (120 chars)
 
 Intent: {intent}
-- "block" (blacklist): Keep the description broad enough to catch violations, but remove noise that causes false positives on unrelated content.
-- "allow" (whitelist): Make the description precise enough that only truly matching content triggers, with no semantic bleed into adjacent domains.
+- "block": Keep broad enough to catch violations. Remove noise causing false positives.
+- "allow": Keep precise. No semantic bleed into adjacent domains.
 {memorySection}`,
   ],
   [
     'human',
-    `The current definition has been over-refined and coverage is regressing. Simplify it.
+    `Coverage is regressing due to over-refinement. Return to the simpler definition that worked.
 
-Current Definition (over-refined):
+Best-Performing Definition (achieved {bestCoverage} coverage — START HERE):
+- Description: {bestDescription}
+- Examples: {bestExamples}
+
+Current Definition (over-refined, only {coverage} coverage):
 - Name: {currentName}
 - Description: {currentDescription}
 - Examples: {currentExamples}
 
-Best-Performing Definition (simpler, achieved {bestCoverage} coverage):
-- Description: {bestDescription}
-- Examples: {bestExamples}
-
 Current Performance:
-- Coverage: {coverage}
 - TPR: {tpr}, TNR: {tnr}
 
-Generate a SIMPLER topic definition that reverts toward the best-performing version while incorporating any genuine improvements from refinement iterations. Prioritize brevity and clarity over specificity.`,
+Return the best-performing definition with at most minor wording tweaks. Do NOT add specificity or qualifiers. Fewer words = better performance.`,
   ],
 ]);

--- a/tests/unit/llm/prompts.spec.ts
+++ b/tests/unit/llm/prompts.spec.ts
@@ -177,7 +177,7 @@ Consider reverting toward this simpler definition rather than adding more specif
     expect(vars).toContain('memorySection');
   });
 
-  it('simplifyTopicPrompt system message includes simplification guidance', async () => {
+  it('simplifyTopicPrompt system message includes anti-specificity guidance', async () => {
     const messages = await simplifyTopicPrompt.formatMessages({
       currentName: 'Test',
       currentDescription: 'Long over-refined description with not X and excludes Y',
@@ -192,9 +192,33 @@ Consider reverting toward this simpler definition rather than adding more specif
       memorySection: '',
     });
     const systemContent = messages[0].content as string;
-    expect(systemContent).toContain('SIMPLIFICATION WORKS');
-    expect(systemContent).toContain('under 100 chars');
-    expect(systemContent).toContain('Exclusion clauses');
+    expect(systemContent).toContain('Do NOT add qualifiers');
+    expect(systemContent).toContain('UNDER 80 characters');
+    expect(systemContent).toContain('GOOD vs BAD');
+    expect(systemContent).toContain('Cooking recipes for specific dishes');
+  });
+
+  it('simplifyTopicPrompt human message leads with best-performing definition', async () => {
+    const messages = await simplifyTopicPrompt.formatMessages({
+      currentName: 'Test',
+      currentDescription: 'Over-refined version',
+      currentExamples: 'ex1, ex2, ex3',
+      bestCoverage: '66.0%',
+      bestDescription: 'Short best description',
+      bestExamples: 'ex1, ex2',
+      coverage: '40.0%',
+      tpr: '80.0%',
+      tnr: '40.0%',
+      intent: 'allow',
+      memorySection: '',
+    });
+    const humanContent = messages[1].content as string;
+    // Best definition should appear BEFORE current definition
+    const bestIdx = humanContent.indexOf('Short best description');
+    const currentIdx = humanContent.indexOf('Over-refined version');
+    expect(bestIdx).toBeGreaterThan(-1);
+    expect(currentIdx).toBeGreaterThan(-1);
+    expect(bestIdx).toBeLessThan(currentIdx);
   });
 
   it('improveTopicPrompt omits regression warning when coverage is at or above best', async () => {


### PR DESCRIPTION
## Summary
- Rewrite `simplifyTopicPrompt` with stronger anti-specificity enforcement
- Lead human message with best-performing definition (placed before current definition)
- Add concrete GOOD vs BAD simplification examples in system prompt
- Target 80 chars description length (down from 100)
- Explicit "Do NOT add qualifiers, specificity, or new constraints" instruction
- Removed permission to "incorporate genuine improvements" that caused LLM to add specificity back

## Test plan
- [x] 454 tests pass (1 new: human message ordering test)
- [x] TypeScript compiles cleanly
- [x] Biome lint passes

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)