### PR TITLE
feat: add coverage plateau detection

### DIFF
--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -47,6 +47,8 @@ export function registerGenerateCommand(program: Command): void {
       'Stop after N consecutive coverage regressions (0 = disable)',
       '3',
     )
+    .option('--plateau-window <n>', 'Iterations to check for plateau (0 = disable)', '0')
+    .option('--plateau-band <pct>', 'Max coverage variance for plateau detection', '0.05')
     .option('--accumulate-tests', 'Carry forward test prompts across iterations', false)
     .option('--max-accumulated-tests <n>', 'Max accumulated test count cap')
     .option('--memory', 'Enable learning memory (default)')
@@ -74,6 +76,8 @@ export function registerGenerateCommand(program: Command): void {
             maxIterations: Number.parseInt(opts.maxIterations, 10),
             targetCoverage: Number.parseInt(opts.targetCoverage, 10) / 100,
             maxRegressions: Number.parseInt(opts.maxRegressions, 10),
+            plateauWindow: Number.parseInt(opts.plateauWindow, 10),
+            plateauBand: Number.parseFloat(opts.plateauBand),
             accumulateTests: opts.accumulateTests ?? false,
             maxAccumulatedTests: opts.maxAccumulatedTests
               ? Number.parseInt(opts.maxAccumulatedTests, 10)
@@ -192,6 +196,14 @@ export function registerGenerateCommand(program: Command): void {
             case 'topic:duplicate':
               console.log(
                 `  ⚠ Topic identical to iteration ${event.duplicateOfIteration} — skipping scan`,
+              );
+              break;
+            case 'loop:plateau':
+              console.log(
+                `  ⚠ Coverage plateaued at ${(event.band[0] * 100).toFixed(1)}–${(event.band[1] * 100).toFixed(1)}%`,
+              );
+              console.log(
+                `    Platform ceiling likely reached (best: ${(event.bestCoverage * 100).toFixed(1)}%)`,
               );
               break;
             case 'memory:extracted':

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -498,6 +498,23 @@ export async function* runLoop(
     if (maxRegressions > 0 && runState.consecutiveRegressions >= maxRegressions) {
       break;
     }
+
+    // Plateau detection: coverage oscillating in narrow band without improvement (opt-in)
+    const plateauWindow = input.plateauWindow ?? 0;
+    const plateauBand = input.plateauBand ?? 0.05;
+    if (plateauWindow > 0 && runState.iterations.length >= plateauWindow + 1) {
+      const recent = runState.iterations.slice(-plateauWindow).map((r) => r.metrics.coverage);
+      const min = Math.min(...recent);
+      const max = Math.max(...recent);
+      if (max - min <= plateauBand && max < runState.bestCoverage + plateauBand) {
+        yield {
+          type: 'loop:plateau' as const,
+          band: [min, max],
+          bestCoverage: runState.bestCoverage,
+        };
+        break;
+      }
+    }
   }
 
   runState.status = 'completed';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -22,6 +22,8 @@ export interface UserInput {
   maxIterations?: number;
   targetCoverage?: number;
   maxRegressions?: number;
+  plateauWindow?: number;
+  plateauBand?: number;
   accumulateTests?: boolean;
   maxAccumulatedTests?: number;
   createPromptSet?: boolean;
@@ -137,5 +139,6 @@ export type LoopEvent =
   | { type: 'memory:extracted'; learningCount: number }
   | { type: 'topic:simplified'; topic: CustomTopic }
   | { type: 'topic:reverted'; topic: CustomTopic; revertedToIteration: number }
+  | { type: 'loop:plateau'; band: [number, number]; bestCoverage: number }
   | { type: 'topic:duplicate'; topic: CustomTopic; duplicateOfIteration: number }
   | { type: 'promptset:created'; promptSetId: string; promptSetName: string; promptCount: number };

--- a/tests/unit/core/loop.spec.ts
+++ b/tests/unit/core/loop.spec.ts
@@ -1326,6 +1326,152 @@ describe('runLoop', () => {
     });
   });
 
+  describe('plateau detection', () => {
+    it('detects plateau when last N iterations are within band', async () => {
+      const llm = createMockLlm();
+      // All iterations return same coverage → plateau
+      const deps = createDeps({ llm, scanner: createMockScanService([]) });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        {
+          ...defaultInput,
+          maxIterations: 20,
+          targetCoverage: 0.99,
+          maxRegressions: 0, // disable early stopping to test plateau
+          plateauWindow: 3,
+          plateauBand: 0.05,
+        },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const plateau = events.find((e) => e.type === 'loop:plateau');
+      expect(plateau).toBeDefined();
+      if (plateau?.type === 'loop:plateau') {
+        expect(plateau.band[1] - plateau.band[0]).toBeLessThanOrEqual(0.05);
+      }
+    });
+
+    it('does not trigger plateau in early iterations', async () => {
+      const llm = createMockLlm();
+      const deps = createDeps({ llm, scanner: createMockScanService([]) });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        {
+          ...defaultInput,
+          maxIterations: 3, // fewer than plateauWindow + 1
+          targetCoverage: 0.99,
+          maxRegressions: 0,
+          plateauWindow: 3,
+        },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const plateau = events.find((e) => e.type === 'loop:plateau');
+      expect(plateau).toBeUndefined();
+    });
+
+    it('does not trigger plateau when coverage is improving', async () => {
+      const llm = createMockLlm();
+      let scanCall = 0;
+      const scanner = createMockScanService([]);
+      const origBatch = scanner.scanBatch;
+      scanner.scanBatch = async (profile, prompts, conc, sess) => {
+        scanCall++;
+        // Each iteration triggers more patterns → improving coverage
+        if (scanCall <= 3) {
+          const patterns = [/weapon/i, /bomb/i, /gun/i].slice(0, scanCall);
+          return prompts.map((p) => ({
+            scanId: 's1',
+            reportId: 'r1',
+            action: 'block' as const,
+            triggered: patterns.some((pat) => pat.test(p)),
+            category: patterns.some((pat) => pat.test(p)) ? 'malicious' : 'benign',
+          }));
+        }
+        return origBatch(profile, prompts, conc, sess);
+      };
+
+      const deps = createDeps({ llm, scanner });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        {
+          ...defaultInput,
+          maxIterations: 4,
+          targetCoverage: 0.99,
+          maxRegressions: 0,
+          plateauWindow: 3,
+        },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const plateau = events.find((e) => e.type === 'loop:plateau');
+      expect(plateau).toBeUndefined();
+    });
+
+    it('respects custom plateauWindow and plateauBand', async () => {
+      const llm = createMockLlm();
+      const deps = createDeps({ llm, scanner: createMockScanService([]) });
+      const events: LoopEvent[] = [];
+
+      // With window=2 and band=0.1, plateau triggers sooner
+      for await (const event of runLoop(
+        {
+          ...defaultInput,
+          maxIterations: 20,
+          targetCoverage: 0.99,
+          maxRegressions: 0,
+          plateauWindow: 2,
+          plateauBand: 0.1,
+        },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const plateau = events.find((e) => e.type === 'loop:plateau');
+      expect(plateau).toBeDefined();
+      // With window=2, should trigger by iteration 3 (need 2+1 iterations)
+      const starts = events.filter((e) => e.type === 'iteration:start');
+      expect(starts.length).toBeLessThanOrEqual(5);
+    });
+
+    it('yields loop:plateau event with correct band values', async () => {
+      const llm = createMockLlm();
+      const deps = createDeps({ llm, scanner: createMockScanService([]) });
+      const events: LoopEvent[] = [];
+
+      for await (const event of runLoop(
+        {
+          ...defaultInput,
+          maxIterations: 20,
+          targetCoverage: 0.99,
+          maxRegressions: 0,
+          plateauWindow: 3,
+        },
+        deps,
+      )) {
+        events.push(event);
+      }
+
+      const plateau = events.find((e) => e.type === 'loop:plateau');
+      expect(plateau).toBeDefined();
+      if (plateau?.type === 'loop:plateau') {
+        expect(plateau.bestCoverage).toBeGreaterThanOrEqual(0);
+        expect(plateau.band).toHaveLength(2);
+        expect(plateau.band[0]).toBeLessThanOrEqual(plateau.band[1]);
+      }
+    });
+  });
+
   describe('test composition (carry-forward + regression)', () => {
     it('yields tests:composed on iteration 2+ with correct counts', async () => {
       const llm = createMockLlm();


### PR DESCRIPTION
## Summary
- Add opt-in plateau detection: `--plateau-window <n>` (default 0 = disabled)
- When enabled, if last N iterations are within ±band% without exceeding best coverage, yields `loop:plateau` event and stops
- Configurable via `--plateau-window` and `--plateau-band` CLI options
- Add `plateauWindow`, `plateauBand` to `UserInput`; `loop:plateau` to `LoopEvent`

## Test plan
- [x] 459 tests pass (5 new: plateau triggers, early iterations skip, improving coverage skip, custom params, event values)
- [x] TypeScript compiles cleanly
- [x] Biome lint passes

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)