### PR TITLE
feat: surface allow-intent coverage ceiling warning

### DIFF
--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -144,6 +144,15 @@ export function registerGenerateCommand(program: Command): void {
             })
           : undefined;
 
+        // Warn about allow-intent coverage expectations
+        if (userInput.intent === 'allow') {
+          console.log(
+            '  \u26A0 Allow-intent topics typically achieve 40\u201370% coverage due to AIRS semantic matching.',
+          );
+          console.log('    Consider using --target-coverage 65 for realistic expectations.');
+          console.log();
+        }
+
         // Run the loop
         for await (const event of runLoop(userInput, {
           llm,


### PR DESCRIPTION
## Summary
- Display warning before loop starts for allow-intent runs
- Informs users that 40–70% coverage is typical due to AIRS semantic matching
- Suggests `--target-coverage 65` for realistic expectations
- Warning only appears for allow-intent, not block-intent

## Test plan
- [x] 459 tests pass
- [x] TypeScript compiles cleanly
- [x] Biome lint passes

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)