### PR TITLE
docs: fix README labels command, add JSDoc, document Zod min examples (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ daystrom model-security scans violations <scanUuid>
 daystrom model-security scans files <scanUuid>
 
 # Labels and PyPI auth
-daystrom model-security labels list
+daystrom model-security labels keys
 daystrom model-security pypi-auth
 ```
 

--- a/src/airs/scanner.ts
+++ b/src/airs/scanner.ts
@@ -3,6 +3,7 @@ import { Content, init, Scanner } from '@cdot65/prisma-airs-sdk';
 import pLimit from 'p-limit';
 import type { ScanResult, ScanService } from './types.js';
 
+/** Scans prompts against AIRS security profiles via the Prisma AIRS SDK. */
 export class AirsScanService implements ScanService {
   private scanner: InstanceType<typeof Scanner>;
 
@@ -11,6 +12,7 @@ export class AirsScanService implements ScanService {
     this.scanner = new Scanner();
   }
 
+  /** Scan a single prompt synchronously and return the normalized result. */
   async scan(profileName: string, prompt: string, sessionId?: string): Promise<ScanResult> {
     const content = new Content({ prompt });
     const response = await this.scanner.syncScan(
@@ -34,6 +36,7 @@ export class AirsScanService implements ScanService {
     };
   }
 
+  /** Scan multiple prompts concurrently (default 5) and return results in order. */
   async scanBatch(
     profileName: string,
     prompts: string[],

--- a/src/llm/schemas.ts
+++ b/src/llm/schemas.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 export const CustomTopicSchema = z.object({
   name: z.string().min(1),
   description: z.string().min(1),
+  // min(2) at LLM layer: ensures meaningful test coverage. AIRS allows fewer,
+  // but the LLM should always produce at least 2 examples for effective scanning.
   examples: z.array(z.string().min(1)).min(2).max(5),
 });
 


### PR DESCRIPTION
## Summary
Three documentation fixes from code review:
- README line 133: `labels list` → `labels keys` (command doesn't exist)
- `AirsScanService`: add JSDoc to class and public methods
- `schemas.ts`: add comment explaining why `min(2)` examples at LLM layer vs AIRS allowing 0

## Testing
- No code changes — docs/comments only
- All 468 tests passing, lint/typecheck clean

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)