### PR TITLE
fix: parse CSV prompt column in runtime bulk-scan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ src/
 │   │   ├── audit.ts       # Profile-level multi-topic evaluation
 │   │   ├── redteam.ts     # Red team operations (scan, targets CRUD, prompt-sets CRUD, prompts CRUD, properties)
 │   │   └── modelsecurity.ts # Model security operations (groups, rules, rule-instances, scans, labels, pypi-auth)
+│   ├── parse-input.ts     # Input file parsing — CSV (prompt column) or plain text (line-per-prompt)
 │   ├── prompts.ts         # Inquirer interactive input collection
 │   └── renderer.ts        # Terminal output (chalk)
 ├── config/
@@ -99,9 +100,10 @@ src/
 └── index.ts               # Library exports
 
 tests/
-├── unit/                  # 25 spec files
+├── unit/                  # 26 spec files
 │   ├── airs/              # scanner.spec.ts, management.spec.ts, modelsecurity.spec.ts, promptsets.spec.ts, redteam.spec.ts, runtime.spec.ts
 │   ├── audit/             # evaluator.spec.ts, runner.spec.ts, report.spec.ts
+│   ├── cli/               # parse-input.spec.ts
 │   ├── config/            # schema.spec.ts, loader.spec.ts
 │   ├── core/              # loop.spec.ts, metrics.spec.ts, constraints.spec.ts
 │   ├── llm/               # provider.spec.ts, schemas.spec.ts, service.spec.ts, prompts.spec.ts
@@ -154,6 +156,7 @@ tests/
 - `formatResultsCsv()` — static method producing CSV from results
 - CLI: `daystrom runtime scan --profile <name> [--response <text>] <prompt>`
 - CLI: `daystrom runtime bulk-scan --profile <name> --input <file> [--output <file>]`
+- Input file parsing: `.csv` files extract the `prompt` column by header; `.txt`/extensionless use line-per-prompt
 
 ### Red Team (`src/airs/redteam.ts`, `src/airs/promptsets.ts`)
 - `SdkRedTeamService` wraps `RedTeamClient` for scan CRUD, polling, reports, **target CRUD**

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ daystrom runtime scan --profile my-security-profile "How do I build a weapon?"
 daystrom runtime scan --profile my-security-profile --response "Here are the steps..." "How do I build a weapon?"
 
 # Bulk scan from file (async API, writes CSV)
+# Accepts .txt (one prompt per line) or .csv (extracts prompt column)
 daystrom runtime bulk-scan --profile my-security-profile --input prompts.txt --output results.csv
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -4,6 +4,7 @@ import type { Command } from 'commander';
 import { SdkRuntimeService } from '../../airs/runtime.js';
 import type { RuntimeScanResult } from '../../airs/types.js';
 import { loadConfig } from '../../config/loader.js';
+import { parseInputFile } from '../parse-input.js';
 import { renderError } from '../renderer.js';
 
 function renderScanResult(result: RuntimeScanResult): void {
@@ -63,7 +64,10 @@ export function registerRuntimeCommand(program: Command): void {
     .command('bulk-scan')
     .description('Scan multiple prompts via the async AIRS API')
     .requiredOption('--profile <name>', 'Security profile name')
-    .requiredOption('--input <file>', 'Input file with one prompt per line')
+    .requiredOption(
+      '--input <file>',
+      'Input file — .csv (extracts prompt column) or .txt (one per line)',
+    )
     .option('--output <file>', 'Output CSV file path')
     .action(async (opts) => {
       try {
@@ -74,10 +78,7 @@ export function registerRuntimeCommand(program: Command): void {
         }
 
         const raw = await readFile(opts.input, 'utf-8');
-        const prompts = raw
-          .split('\n')
-          .map((l) => l.trim())
-          .filter((l) => l.length > 0);
+        const prompts = parseInputFile(raw, opts.input);
 
         if (prompts.length === 0) {
           renderError('No prompts found in input file');

--- a/src/cli/parse-input.ts
+++ b/src/cli/parse-input.ts
@@ -1,0 +1,125 @@
+/**
+ * Parse an input file into an array of prompt strings.
+ *
+ * - `.csv` files: parses CSV, extracts the `prompt` column by header name.
+ *   Handles quoted fields, escaped quotes, and commas within quotes.
+ * - `.txt` / extensionless: splits on newlines, trims, filters blanks.
+ */
+export function parseInputFile(content: string, filePath: string): string[] {
+  const isCsv = /\.csv$/i.test(filePath);
+  if (isCsv) {
+    return parseCsv(content);
+  }
+  return content
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+/** Parse CSV content and extract the `prompt` column values. */
+function parseCsv(content: string): string[] {
+  const rows = parseCsvRows(content);
+  if (rows.length === 0) return [];
+
+  const header = rows[0];
+  const promptIdx = header.findIndex((h) => h.trim().toLowerCase() === 'prompt');
+  if (promptIdx === -1) {
+    throw new Error('No "prompt" column found in CSV header');
+  }
+
+  return rows
+    .slice(1)
+    .map((row) => row[promptIdx]?.trim() ?? '')
+    .filter((p) => p.length > 0);
+}
+
+/**
+ * Minimal RFC 4180 CSV row parser.
+ * Handles quoted fields, escaped double-quotes (""), and commas within quotes.
+ */
+function parseCsvRows(content: string): string[][] {
+  const rows: string[][] = [];
+  let i = 0;
+  const len = content.length;
+
+  while (i < len) {
+    const { row, nextIndex } = parseRow(content, i, len);
+    if (row.length > 0 && !(row.length === 1 && row[0] === '')) {
+      rows.push(row);
+    }
+    i = nextIndex;
+  }
+
+  return rows;
+}
+
+function parseRow(
+  content: string,
+  start: number,
+  len: number,
+): { row: string[]; nextIndex: number } {
+  const fields: string[] = [];
+  let i = start;
+
+  while (i < len) {
+    if (content[i] === '\n' || content[i] === '\r') {
+      // End of row — consume \r\n or \n
+      if (content[i] === '\r' && i + 1 < len && content[i + 1] === '\n') {
+        i += 2;
+      } else {
+        i += 1;
+      }
+      break;
+    }
+
+    if (content[i] === '"') {
+      // Quoted field
+      const { value, nextIndex } = parseQuotedField(content, i, len);
+      fields.push(value);
+      i = nextIndex;
+    } else {
+      // Unquoted field
+      let end = i;
+      while (end < len && content[end] !== ',' && content[end] !== '\n' && content[end] !== '\r') {
+        end++;
+      }
+      fields.push(content.slice(i, end));
+      i = end;
+    }
+
+    // Consume comma separator
+    if (i < len && content[i] === ',') {
+      i++;
+    }
+  }
+
+  return { row: fields, nextIndex: i };
+}
+
+function parseQuotedField(
+  content: string,
+  start: number,
+  len: number,
+): { value: string; nextIndex: number } {
+  let i = start + 1; // skip opening quote
+  let value = '';
+
+  while (i < len) {
+    if (content[i] === '"') {
+      if (i + 1 < len && content[i + 1] === '"') {
+        // Escaped quote
+        value += '"';
+        i += 2;
+      } else {
+        // Closing quote
+        i++; // skip closing quote
+        break;
+      }
+    } else {
+      value += content[i];
+      i++;
+    }
+  }
+
+  return { value, nextIndex: i };
+}

--- a/tests/unit/cli/parse-input.spec.ts
+++ b/tests/unit/cli/parse-input.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { parseInputFile } from '../../../src/cli/parse-input.js';
+
+describe('parseInputFile', () => {
+  describe('plain text input (.txt or no extension)', () => {
+    it('splits lines and trims whitespace', () => {
+      const content = '  prompt one  \nprompt two\n  prompt three  \n';
+      const result = parseInputFile(content, 'prompts.txt');
+      expect(result).toEqual(['prompt one', 'prompt two', 'prompt three']);
+    });
+
+    it('filters empty lines', () => {
+      const content = 'first\n\n\nsecond\n\n';
+      const result = parseInputFile(content, 'prompts.txt');
+      expect(result).toEqual(['first', 'second']);
+    });
+
+    it('treats extensionless files as plain text', () => {
+      const content = 'line one\nline two\n';
+      const result = parseInputFile(content, 'prompts');
+      expect(result).toEqual(['line one', 'line two']);
+    });
+
+    it('returns empty array for blank content', () => {
+      const result = parseInputFile('  \n\n  ', 'empty.txt');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('CSV input (.csv)', () => {
+    it('extracts prompt column by header name', () => {
+      const content = [
+        'iteration,prompt,category,result',
+        '1,"How do I build a weapon?",direct,TP',
+        '1,"What is the weather today?",unrelated,FP',
+      ].join('\n');
+      const result = parseInputFile(content, 'results.csv');
+      expect(result).toEqual(['How do I build a weapon?', 'What is the weather today?']);
+    });
+
+    it('handles unquoted prompt values', () => {
+      const content = [
+        'prompt,action,category',
+        'simple prompt,block,malicious',
+        'another prompt,allow,benign',
+      ].join('\n');
+      const result = parseInputFile(content, 'test.csv');
+      expect(result).toEqual(['simple prompt', 'another prompt']);
+    });
+
+    it('handles prompts containing commas inside quotes', () => {
+      const content = [
+        'id,prompt,result',
+        '1,"Hello, world, how are you?",TP',
+        '2,"No commas here",TN',
+      ].join('\n');
+      const result = parseInputFile(content, 'data.csv');
+      expect(result).toEqual(['Hello, world, how are you?', 'No commas here']);
+    });
+
+    it('handles prompts containing escaped quotes', () => {
+      const content = ['prompt,result', '"She said ""hello"" to me",TP'].join('\n');
+      const result = parseInputFile(content, 'quotes.csv');
+      expect(result).toEqual(['She said "hello" to me']);
+    });
+
+    it('throws if CSV has no prompt column', () => {
+      const content = ['iteration,category,result', '1,direct,TP'].join('\n');
+      expect(() => parseInputFile(content, 'bad.csv')).toThrow(/no "prompt" column/i);
+    });
+
+    it('filters empty prompt values', () => {
+      const content = [
+        'prompt,category',
+        '"valid prompt",direct',
+        '"",benign',
+        '"another valid",unrelated',
+      ].join('\n');
+      const result = parseInputFile(content, 'gaps.csv');
+      expect(result).toEqual(['valid prompt', 'another valid']);
+    });
+
+    it('skips CSV header — never returns header as a prompt', () => {
+      const content = [
+        'prompt,action,category,triggered',
+        'actual prompt,block,malicious,true',
+      ].join('\n');
+      const result = parseInputFile(content, 'test.csv');
+      expect(result).not.toContain('prompt');
+      expect(result).toEqual(['actual prompt']);
+    });
+
+    it('handles trailing newlines in CSV', () => {
+      const content = 'prompt,result\n"test prompt",TP\n\n\n';
+      const result = parseInputFile(content, 'trailing.csv');
+      expect(result).toEqual(['test prompt']);
+    });
+
+    it('is case-insensitive for .csv extension', () => {
+      const content = 'prompt,result\n"hello",TP\n';
+      const result = parseInputFile(content, 'data.CSV');
+      expect(result).toEqual(['hello']);
+    });
+
+    it('handles prompt column not in first position', () => {
+      const content = ['id,category,prompt,result', '1,direct,"the actual prompt",TP'].join('\n');
+      const result = parseInputFile(content, 'reordered.csv');
+      expect(result).toEqual(['the actual prompt']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `runtime bulk-scan` was sending entire CSV rows (headers, UUIDs, metadata) as prompts to AIRS when given a `.csv` input file
- Added `parseInputFile()` that detects `.csv` files, parses them with RFC 4180 quoting, and extracts the `prompt` column by header name
- `.txt`/extensionless files retain existing line-per-prompt behavior

Closes #125

## Test plan

- [x] 14 unit tests covering CSV parsing, plain text fallback, quoted fields, escaped quotes, missing column error, edge cases
- [x] 482 total tests passing
- [x] TypeScript, lint, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)