### PR TITLE
feat: persist bulk-scan IDs and add resume-poll command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ src/
 │   │   ├── audit.ts       # Profile-level multi-topic evaluation
 │   │   ├── redteam.ts     # Red team operations (scan, targets CRUD, prompt-sets CRUD, prompts CRUD, properties)
 │   │   └── modelsecurity.ts # Model security operations (groups, rules, rule-instances, scans, labels, pypi-auth)
+│   ├── bulk-scan-state.ts # Save/load bulk scan IDs for resume after poll failure
 │   ├── parse-input.ts     # Input file parsing — CSV (prompt column) or plain text (line-per-prompt)
 │   ├── prompts.ts         # Inquirer interactive input collection
 │   └── renderer.ts        # Terminal output (chalk)
@@ -100,10 +101,10 @@ src/
 └── index.ts               # Library exports
 
 tests/
-├── unit/                  # 26 spec files
+├── unit/                  # 27 spec files
 │   ├── airs/              # scanner.spec.ts, management.spec.ts, modelsecurity.spec.ts, promptsets.spec.ts, redteam.spec.ts, runtime.spec.ts
 │   ├── audit/             # evaluator.spec.ts, runner.spec.ts, report.spec.ts
-│   ├── cli/               # parse-input.spec.ts
+│   ├── cli/               # parse-input.spec.ts, bulk-scan-state.spec.ts
 │   ├── config/            # schema.spec.ts, loader.spec.ts
 │   ├── core/              # loop.spec.ts, metrics.spec.ts, constraints.spec.ts
 │   ├── llm/               # provider.spec.ts, schemas.spec.ts, service.spec.ts, prompts.spec.ts
@@ -157,6 +158,8 @@ tests/
 - CLI: `daystrom runtime scan --profile <name> [--response <text>] <prompt>`
 - CLI: `daystrom runtime bulk-scan --profile <name> --input <file> [--output <file>]`
 - Input file parsing: `.csv` files extract the `prompt` column by header; `.txt`/extensionless use line-per-prompt
+- Bulk scan IDs are saved to `~/.daystrom/bulk-scans/` before polling — survives rate limit crashes
+- CLI: `daystrom runtime resume-poll <stateFile> [--output <file>]` — resume polling from saved scan IDs
 
 ### Red Team (`src/airs/redteam.ts`, `src/airs/promptsets.ts`)
 - `SdkRedTeamService` wraps `RedTeamClient` for scan CRUD, polling, reports, **target CRUD**

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ daystrom generate \
 | `daystrom resume <runId>` | Resume a paused or failed generation run |
 | `daystrom report <runId>` | View results for a saved run (terminal, JSON, HTML) |
 | `daystrom list` | List all saved runs |
-| `daystrom runtime` | Runtime prompt scanning — sync and async bulk |
+| `daystrom runtime` | Runtime prompt scanning — sync, async bulk, and resume-poll |
 | `daystrom audit` | Evaluate all topics in a security profile — per-topic metrics + conflict detection |
 | `daystrom redteam` | Red team scanning — targets, prompt sets, scans, reports |
 | `daystrom model-security` | ML model supply chain security — groups, rules, scans, labels |
@@ -86,6 +86,9 @@ daystrom runtime scan --profile my-security-profile --response "Here are the ste
 # Bulk scan from file (async API, writes CSV)
 # Accepts .txt (one prompt per line) or .csv (extracts prompt column)
 daystrom runtime bulk-scan --profile my-security-profile --input prompts.txt --output results.csv
+
+# Resume polling if bulk-scan was interrupted (scan IDs saved to ~/.daystrom/bulk-scans/)
+daystrom runtime resume-poll ~/.daystrom/bulk-scans/2026-03-11T12-00-00-000Z.bulk-scan.json
 ```
 
 ### Red Team

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/bulk-scan-state.ts
+++ b/src/cli/bulk-scan-state.ts
@@ -1,0 +1,28 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+export interface BulkScanState {
+  scanIds: string[];
+  profile: string;
+  promptCount: number;
+  timestamp?: string;
+}
+
+/**
+ * Persist bulk scan IDs to a JSON file so polling can be resumed
+ * if the process crashes or hits a rate limit.
+ */
+export async function saveBulkScanState(state: BulkScanState, dir: string): Promise<string> {
+  await fs.mkdir(dir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const filePath = path.join(dir, `${ts}.bulk-scan.json`);
+  const payload = { ...state, timestamp: new Date().toISOString() };
+  await fs.writeFile(filePath, JSON.stringify(payload, null, 2), 'utf-8');
+  return filePath;
+}
+
+/** Load a previously saved bulk scan state file. */
+export async function loadBulkScanState(filePath: string): Promise<BulkScanState> {
+  const raw = await fs.readFile(filePath, 'utf-8');
+  return JSON.parse(raw) as BulkScanState;
+}

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -4,6 +4,7 @@ import type { Command } from 'commander';
 import { SdkRuntimeService } from '../../airs/runtime.js';
 import type { RuntimeScanResult } from '../../airs/types.js';
 import { loadConfig } from '../../config/loader.js';
+import { loadBulkScanState, saveBulkScanState } from '../bulk-scan-state.js';
 import { parseInputFile } from '../parse-input.js';
 import { renderError } from '../renderer.js';
 
@@ -93,6 +94,13 @@ export function registerRuntimeCommand(program: Command): void {
 
         console.log(chalk.dim('  Submitting async scans...'));
         const scanIds = await service.submitBulkScan(opts.profile, prompts);
+
+        const stateDir = config.dataDir.replace(/\/runs$/, '/bulk-scans');
+        const statePath = await saveBulkScanState(
+          { scanIds, profile: opts.profile, promptCount: prompts.length },
+          stateDir,
+        );
+        console.log(chalk.dim(`  Scan IDs saved: ${statePath}`));
         console.log(chalk.dim(`  Submitted ${scanIds.length} batch(es), polling for results...`));
 
         const results = await service.pollResults(scanIds);
@@ -110,6 +118,48 @@ export function registerRuntimeCommand(program: Command): void {
         const allowed = results.filter((r) => r.action === 'allow').length;
 
         console.log(chalk.bold('\n  Bulk Scan Complete'));
+        console.log(chalk.dim('  ─────────────────────────'));
+        console.log(`  Total:   ${results.length}`);
+        console.log(`  Blocked: ${chalk.red(String(blocked))}`);
+        console.log(`  Allowed: ${chalk.green(String(allowed))}`);
+        console.log(`  Output:  ${chalk.cyan(outputPath)}\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  runtime
+    .command('resume-poll <stateFile>')
+    .description('Resume polling for a previously submitted bulk scan')
+    .option('--output <file>', 'Output CSV file path')
+    .action(async (stateFile: string, opts) => {
+      try {
+        const config = await loadConfig({});
+        if (!config.airsApiKey) {
+          renderError('PANW_AI_SEC_API_KEY is required');
+          process.exit(1);
+        }
+
+        const state = await loadBulkScanState(stateFile);
+        const service = new SdkRuntimeService(config.airsApiKey);
+
+        console.log(chalk.bold.cyan('\n  Prisma AIRS Resume Poll'));
+        console.log(chalk.dim(`  Profile:  ${state.profile}`));
+        console.log(chalk.dim(`  Scan IDs: ${state.scanIds.length}`));
+        console.log(chalk.dim(`  Prompts:  ${state.promptCount}\n`));
+
+        console.log(chalk.dim('  Polling for results...'));
+        const results = await service.pollResults(state.scanIds);
+
+        const outputPath = opts.output ?? `${state.profile.replace(/\s+/g, '-')}-bulk-scan.csv`;
+        const csv = SdkRuntimeService.formatResultsCsv(results);
+        await writeFile(outputPath, csv, 'utf-8');
+
+        const blocked = results.filter((r) => r.action === 'block').length;
+        const allowed = results.filter((r) => r.action === 'allow').length;
+
+        console.log(chalk.bold('\n  Resume Poll Complete'));
         console.log(chalk.dim('  ─────────────────────────'));
         console.log(`  Total:   ${results.length}`);
         console.log(`  Blocked: ${chalk.red(String(blocked))}`);

--- a/tests/unit/cli/bulk-scan-state.spec.ts
+++ b/tests/unit/cli/bulk-scan-state.spec.ts
@@ -1,0 +1,69 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadBulkScanState, saveBulkScanState } from '../../../src/cli/bulk-scan-state.js';
+
+describe('bulk-scan-state', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(import.meta.dirname ?? '/tmp', 'bss-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('saveBulkScanState', () => {
+    it('writes scan IDs and profile to a JSON file', async () => {
+      const filePath = await saveBulkScanState(
+        { scanIds: ['id-1', 'id-2'], profile: 'my-profile', promptCount: 10 },
+        tmpDir,
+      );
+
+      const content = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+      expect(content.scanIds).toEqual(['id-1', 'id-2']);
+      expect(content.profile).toBe('my-profile');
+      expect(content.promptCount).toBe(10);
+      expect(content.timestamp).toBeDefined();
+    });
+
+    it('creates file with .bulk-scan.json suffix', async () => {
+      const filePath = await saveBulkScanState(
+        { scanIds: ['id-1'], profile: 'p', promptCount: 1 },
+        tmpDir,
+      );
+
+      expect(filePath).toMatch(/\.bulk-scan\.json$/);
+    });
+
+    it('creates the directory if it does not exist', async () => {
+      const nestedDir = path.join(tmpDir, 'nested', 'deep');
+      const filePath = await saveBulkScanState(
+        { scanIds: ['id-1'], profile: 'p', promptCount: 1 },
+        nestedDir,
+      );
+
+      const content = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+      expect(content.scanIds).toEqual(['id-1']);
+    });
+  });
+
+  describe('loadBulkScanState', () => {
+    it('reads saved state from a JSON file', async () => {
+      const filePath = await saveBulkScanState(
+        { scanIds: ['a', 'b', 'c'], profile: 'test-profile', promptCount: 15 },
+        tmpDir,
+      );
+
+      const state = await loadBulkScanState(filePath);
+      expect(state.scanIds).toEqual(['a', 'b', 'c']);
+      expect(state.profile).toBe('test-profile');
+      expect(state.promptCount).toBe(15);
+    });
+
+    it('throws for non-existent file', async () => {
+      await expect(loadBulkScanState(path.join(tmpDir, 'nope.json'))).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Bulk scan IDs are now saved to `~/.daystrom/bulk-scans/` immediately after submission, before polling begins
- New `daystrom runtime resume-poll <stateFile>` command resumes polling from saved scan IDs
- If `pollResults()` crashes (e.g., rate limit), scan IDs survive and can be resumed

Closes #127

## Test plan

- [x] 5 unit tests for save/load bulk scan state
- [x] 487 total tests passing
- [x] TypeScript, lint, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)