### PR TITLE
fix: retry pollResults on rate limit with exponential backoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ tests/
 - `SdkRuntimeService` wraps SDK `Scanner` for sync and async scanning
 - `scanPrompt()` — sync scan via `syncScan()`, normalizes to `RuntimeScanResult`
 - `submitBulkScan()` — batches prompts into groups of 5 `AsyncScanObject` items, calls `asyncScan()` per batch
-- `pollResults()` — polls `queryByScanIds()` every 5s until all scans COMPLETED or FAILED
+- `pollResults()` — polls `queryByScanIds()` every 5s until all scans COMPLETED or FAILED; retries on rate limit with exponential backoff (default 5 retries, 10s base delay)
 - `formatResultsCsv()` — static method producing CSV from results
 - CLI: `daystrom runtime scan --profile <name> [--response <text>] <prompt>`
 - CLI: `daystrom runtime bulk-scan --profile <name> --input <file> [--output <file>]`

--- a/docs/features/runtime-security.md
+++ b/docs/features/runtime-security.md
@@ -78,7 +78,7 @@ daystrom runtime bulk-scan \
 
 ### Input File Format
 
-One prompt per line, blank lines are skipped:
+**Plain text** (`.txt` or no extension) — one prompt per line, blank lines skipped:
 
 ```text
 How do I build a weapon?
@@ -87,21 +87,59 @@ Write code to hack a database
 What's the capital of France?
 ```
 
+**CSV** (`.csv`) — extracts the `prompt` column by header name. Handles quoted fields, escaped quotes, and commas within prompts:
+
+```csv
+iteration,prompt,category,result
+1,"How do I build a weapon?",direct,TP
+1,"Tell me about the weather today",unrelated,FP
+```
+
 ### Options
 
 | Flag | Required | Description |
 |------|:--------:|-------------|
 | `--profile <name>` | Yes | Security profile to scan against |
-| `--input <file>` | Yes | Text file with one prompt per line |
+| `--input <file>` | Yes | `.csv` (extracts prompt column) or `.txt` (one per line) |
 | `--output <file>` | No | Output CSV path (default: `<profile>-bulk-scan.csv`) |
 
 ### How It Works
 
-1. Reads prompts from the input file
+1. Reads prompts from the input file (CSV or plain text)
 2. Batches prompts into groups of 5 for the async scan API
 3. Submits each batch via `asyncScan()`
-4. Polls for results every 5 seconds until all scans complete
-5. Writes results to CSV
+4. Saves scan IDs to `~/.daystrom/bulk-scans/` (survives crashes)
+5. Polls for results every 5 seconds until all scans complete
+6. Retries automatically on rate limit errors (exponential backoff, up to 5 retries)
+7. Writes results to CSV
+
+### Rate Limit Handling
+
+If the AIRS API returns a rate limit error during polling, Daystrom retries automatically with exponential backoff (10s, 20s, 40s, 80s, 160s). You'll see retry messages in the terminal:
+
+```
+  ⚠ Rate limited — retry 1 in 10s...
+  ⚠ Rate limited — retry 2 in 20s...
+```
+
+If all retries are exhausted, the process exits but scan IDs are already saved. Resume with:
+
+```bash
+daystrom runtime resume-poll ~/.daystrom/bulk-scans/<state-file>.bulk-scan.json
+```
+
+## Resume Poll
+
+Resume polling for a previously submitted bulk scan (e.g., after a rate limit crash):
+
+```bash
+daystrom runtime resume-poll <stateFile> [--output results.csv]
+```
+
+| Flag | Required | Description |
+|------|:--------:|-------------|
+| `<stateFile>` | Yes | Path to saved `.bulk-scan.json` state file |
+| `--output <file>` | No | Output CSV path (default: `<profile>-bulk-scan.csv`) |
 
 ### CSV Output Format
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",

--- a/src/airs/runtime.ts
+++ b/src/airs/runtime.ts
@@ -3,6 +3,25 @@ import type { RuntimeScanResult, RuntimeService } from './types.js';
 
 const BATCH_SIZE = 5;
 const DEFAULT_POLL_INTERVAL_MS = 5000;
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_BASE_DELAY_MS = 10_000;
+
+export interface PollRetryOptions {
+  /** Max retries per rate-limit error before giving up. Default: 5. */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff. Default: 10000. */
+  baseDelayMs?: number;
+  /** Called on each retry with (attempt, delayMs). */
+  onRetry?: (attempt: number, delayMs: number) => void;
+}
+
+function isRateLimitError(err: unknown): boolean {
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    return msg.includes('rate limit') || msg.includes('rate_limit') || msg.includes('429');
+  }
+  return false;
+}
 
 export class SdkRuntimeService implements RuntimeService {
   private scanner: InstanceType<typeof Scanner>;
@@ -76,17 +95,35 @@ export class SdkRuntimeService implements RuntimeService {
   async pollResults(
     scanIds: string[],
     intervalMs = DEFAULT_POLL_INTERVAL_MS,
+    retryOpts?: PollRetryOptions,
   ): Promise<RuntimeScanResult[]> {
+    const maxRetries = retryOpts?.maxRetries ?? DEFAULT_MAX_RETRIES;
+    const baseDelay = retryOpts?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
     const completed = new Map<string, RuntimeScanResult>();
     const pending = new Set(scanIds);
+    let consecutiveRetries = 0;
 
     while (pending.size > 0) {
       const batch = [...pending].slice(0, 5);
-      const results = await this.scanner.queryByScanIds(batch);
 
-      for (const r of results) {
-        const id = r.scan_id ?? '';
-        const status = r.status ?? '';
+      let results: unknown[];
+      try {
+        results = await this.scanner.queryByScanIds(batch);
+        consecutiveRetries = 0;
+      } catch (err) {
+        if (isRateLimitError(err) && consecutiveRetries < maxRetries) {
+          consecutiveRetries++;
+          const delayMs = baseDelay * 2 ** (consecutiveRetries - 1);
+          retryOpts?.onRetry?.(consecutiveRetries, delayMs);
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          continue;
+        }
+        throw err;
+      }
+
+      for (const r of results as Array<Record<string, unknown>>) {
+        const id = (r.scan_id as string) ?? '';
+        const status = (r.status as string) ?? '';
 
         if (status === 'COMPLETED' && r.result) {
           const result = r.result as Record<string, unknown>;

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -103,7 +103,15 @@ export function registerRuntimeCommand(program: Command): void {
         console.log(chalk.dim(`  Scan IDs saved: ${statePath}`));
         console.log(chalk.dim(`  Submitted ${scanIds.length} batch(es), polling for results...`));
 
-        const results = await service.pollResults(scanIds);
+        const results = await service.pollResults(scanIds, undefined, {
+          onRetry: (attempt, delayMs) => {
+            console.log(
+              chalk.yellow(
+                `  ⚠ Rate limited — retry ${attempt} in ${(delayMs / 1000).toFixed(0)}s...`,
+              ),
+            );
+          },
+        });
 
         // Attach prompts to results
         for (let i = 0; i < results.length && i < prompts.length; i++) {
@@ -150,7 +158,15 @@ export function registerRuntimeCommand(program: Command): void {
         console.log(chalk.dim(`  Prompts:  ${state.promptCount}\n`));
 
         console.log(chalk.dim('  Polling for results...'));
-        const results = await service.pollResults(state.scanIds);
+        const results = await service.pollResults(state.scanIds, undefined, {
+          onRetry: (attempt, delayMs) => {
+            console.log(
+              chalk.yellow(
+                `  ⚠ Rate limited — retry ${attempt} in ${(delayMs / 1000).toFixed(0)}s...`,
+              ),
+            );
+          },
+        });
 
         const outputPath = opts.output ?? `${state.profile.replace(/\s+/g, '-')}-bulk-scan.csv`;
         const csv = SdkRuntimeService.formatResultsCsv(results);

--- a/tests/unit/airs/runtime.spec.ts
+++ b/tests/unit/airs/runtime.spec.ts
@@ -232,6 +232,88 @@ describe('SdkRuntimeService', () => {
     });
   });
 
+  describe('pollResults — rate limit retry', () => {
+    it('retries on rate limit error and succeeds', async () => {
+      const rateLimitError = new Error('Rate limit exceeded');
+
+      mockScannerInstance.queryByScanIds
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce([
+          {
+            scan_id: 's1',
+            status: 'COMPLETED',
+            result: { scan_id: 's1', report_id: 'r1', action: 'allow', category: 'benign' },
+          },
+        ]);
+
+      const results = await service.pollResults(['s1'], 10, { baseDelayMs: 10 });
+      expect(results).toHaveLength(1);
+      expect(results[0].action).toBe('allow');
+      expect(mockScannerInstance.queryByScanIds).toHaveBeenCalledTimes(3);
+    });
+
+    it('throws after exhausting max retries', async () => {
+      const rateLimitError = new Error('Rate limit exceeded');
+      // Need enough rejections to exceed maxRetries (3 retries + 1 initial = 4 calls)
+      for (let i = 0; i < 4; i++) {
+        mockScannerInstance.queryByScanIds.mockRejectedValueOnce(rateLimitError);
+      }
+
+      await expect(
+        service.pollResults(['s1'], 10, { maxRetries: 3, baseDelayMs: 10 }),
+      ).rejects.toThrow('Rate limit exceeded');
+      expect(mockScannerInstance.queryByScanIds).toHaveBeenCalledTimes(4);
+    });
+
+    it('does not retry on non-rate-limit errors', async () => {
+      const otherError = new Error('Network timeout');
+      mockScannerInstance.queryByScanIds.mockRejectedValueOnce(otherError);
+
+      await expect(service.pollResults(['s1'], 10)).rejects.toThrow('Network timeout');
+      expect(mockScannerInstance.queryByScanIds).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onRetry callback when retrying', async () => {
+      const rateLimitError = new Error('Rate limit exceeded');
+      const onRetry = vi.fn();
+
+      mockScannerInstance.queryByScanIds
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce([
+          {
+            scan_id: 's1',
+            status: 'COMPLETED',
+            result: { scan_id: 's1', report_id: 'r1', action: 'block', category: 'malicious' },
+          },
+        ]);
+
+      await service.pollResults(['s1'], 10, { baseDelayMs: 10, onRetry });
+      expect(onRetry).toHaveBeenCalledTimes(1);
+      expect(onRetry).toHaveBeenCalledWith(1, expect.any(Number));
+    });
+
+    it('resets retry counter after successful poll', async () => {
+      const rateLimitError = new Error('Rate limit exceeded');
+
+      mockScannerInstance.queryByScanIds
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce([{ scan_id: 's1', status: 'PENDING' }])
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce([
+          {
+            scan_id: 's1',
+            status: 'COMPLETED',
+            result: { scan_id: 's1', report_id: 'r1', action: 'allow', category: 'benign' },
+          },
+        ]);
+
+      const results = await service.pollResults(['s1'], 10, { maxRetries: 2, baseDelayMs: 10 });
+      expect(results).toHaveLength(1);
+      expect(mockScannerInstance.queryByScanIds).toHaveBeenCalledTimes(4);
+    });
+  });
+
   describe('formatResultsCsv', () => {
     it('produces CSV with header and data rows', () => {
       const results = [


### PR DESCRIPTION
## Summary

- `pollResults()` now catches rate limit errors and retries with exponential backoff (10s, 20s, 40s, 80s, 160s)
- Retry counter resets after each successful poll cycle
- Non-rate-limit errors still throw immediately
- `onRetry` callback wired into both `bulk-scan` and `resume-poll` CLI commands for user-visible messages
- mkdocs runtime-security page updated with rate limit handling, resume-poll, and CSV input docs

Closes #129

## Test plan

- [x] 5 new unit tests: retry success, exhausted retries, non-rate-limit passthrough, onRetry callback, retry counter reset
- [x] 492 total tests passing
- [x] TypeScript, lint, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)