### PR TITLE
feat: add session_id to bulk-scan for AIRS Sessions UI grouping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,11 +152,11 @@ tests/
 ### Runtime Scanning (`src/airs/runtime.ts`)
 - `SdkRuntimeService` wraps SDK `Scanner` for sync and async scanning
 - `scanPrompt()` — sync scan via `syncScan()`, normalizes to `RuntimeScanResult`
-- `submitBulkScan()` — batches prompts into groups of 5 `AsyncScanObject` items, calls `asyncScan()` per batch
+- `submitBulkScan()` — batches prompts into groups of 5 `AsyncScanObject` items, calls `asyncScan()` per batch; optional `sessionId` for AIRS Sessions UI grouping
 - `pollResults()` — polls `queryByScanIds()` every 5s until all scans COMPLETED or FAILED; retries on rate limit with exponential backoff (default 5 retries, 10s base delay)
 - `formatResultsCsv()` — static method producing CSV from results
 - CLI: `daystrom runtime scan --profile <name> [--response <text>] <prompt>`
-- CLI: `daystrom runtime bulk-scan --profile <name> --input <file> [--output <file>]`
+- CLI: `daystrom runtime bulk-scan --profile <name> --input <file> [--output <file>] [--session-id <id>]`
 - Input file parsing: `.csv` files extract the `prompt` column by header; `.txt`/extensionless use line-per-prompt
 - Bulk scan IDs are saved to `~/.daystrom/bulk-scans/` before polling — survives rate limit crashes
 - CLI: `daystrom runtime resume-poll <stateFile> [--output <file>]` — resume polling from saved scan IDs

--- a/docs/features/runtime-security.md
+++ b/docs/features/runtime-security.md
@@ -102,6 +102,7 @@ iteration,prompt,category,result
 | `--profile <name>` | Yes | Security profile to scan against |
 | `--input <file>` | Yes | `.csv` (extracts prompt column) or `.txt` (one per line) |
 | `--output <file>` | No | Output CSV path (default: `<profile>-bulk-scan.csv`) |
+| `--session-id <id>` | No | Session ID for grouping scans in AIRS dashboard (auto-generated if omitted) |
 
 ### How It Works
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",

--- a/src/airs/runtime.ts
+++ b/src/airs/runtime.ts
@@ -64,7 +64,11 @@ export class SdkRuntimeService implements RuntimeService {
     };
   }
 
-  async submitBulkScan(profileName: string, prompts: string[]): Promise<string[]> {
+  async submitBulkScan(
+    profileName: string,
+    prompts: string[],
+    sessionId?: string,
+  ): Promise<string[]> {
     const scanIds: string[] = [];
 
     for (let i = 0; i < prompts.length; i += BATCH_SIZE) {
@@ -74,6 +78,7 @@ export class SdkRuntimeService implements RuntimeService {
         scan_req: {
           ai_profile: { profile_name: profileName },
           contents: [{ prompt }],
+          ...(sessionId ? { session_id: sessionId } : {}),
         },
       }));
 

--- a/src/cli/bulk-scan-state.ts
+++ b/src/cli/bulk-scan-state.ts
@@ -5,6 +5,7 @@ export interface BulkScanState {
   scanIds: string[];
   profile: string;
   promptCount: number;
+  sessionId?: string;
   timestamp?: string;
 }
 

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -70,6 +70,7 @@ export function registerRuntimeCommand(program: Command): void {
       'Input file — .csv (extracts prompt column) or .txt (one per line)',
     )
     .option('--output <file>', 'Output CSV file path')
+    .option('--session-id <id>', 'Session ID for grouping scans in AIRS dashboard')
     .action(async (opts) => {
       try {
         const config = await loadConfig({});
@@ -86,18 +87,21 @@ export function registerRuntimeCommand(program: Command): void {
           process.exit(1);
         }
 
+        const sessionId = opts.sessionId ?? `daystrom-bulk-${Date.now().toString(36)}`;
+
         const service = new SdkRuntimeService(config.airsApiKey);
         console.log(chalk.bold.cyan('\n  Prisma AIRS Bulk Scan'));
-        console.log(chalk.dim(`  Profile: ${opts.profile}`));
-        console.log(chalk.dim(`  Prompts: ${prompts.length}`));
-        console.log(chalk.dim(`  Batches: ${Math.ceil(prompts.length / 5)}\n`));
+        console.log(chalk.dim(`  Profile:  ${opts.profile}`));
+        console.log(chalk.dim(`  Session:  ${sessionId}`));
+        console.log(chalk.dim(`  Prompts:  ${prompts.length}`));
+        console.log(chalk.dim(`  Batches:  ${Math.ceil(prompts.length / 5)}\n`));
 
         console.log(chalk.dim('  Submitting async scans...'));
-        const scanIds = await service.submitBulkScan(opts.profile, prompts);
+        const scanIds = await service.submitBulkScan(opts.profile, prompts, sessionId);
 
         const stateDir = config.dataDir.replace(/\/runs$/, '/bulk-scans');
         const statePath = await saveBulkScanState(
-          { scanIds, profile: opts.profile, promptCount: prompts.length },
+          { scanIds, profile: opts.profile, promptCount: prompts.length, sessionId },
           stateDir,
         );
         console.log(chalk.dim(`  Scan IDs saved: ${statePath}`));

--- a/tests/unit/airs/runtime.spec.ts
+++ b/tests/unit/airs/runtime.spec.ts
@@ -110,6 +110,28 @@ describe('SdkRuntimeService', () => {
       expect(secondCall).toHaveLength(2);
     });
 
+    it('passes session_id in scan_req when provided', async () => {
+      mockScannerInstance.asyncScan.mockResolvedValue({
+        received: '2026-03-09T00:00:00Z',
+        scan_id: 'session-scan',
+      });
+
+      await service.submitBulkScan('my-profile', ['test prompt'], 'my-session-123');
+      const scanObj = mockScannerInstance.asyncScan.mock.calls[0][0][0];
+      expect(scanObj.scan_req.session_id).toBe('my-session-123');
+    });
+
+    it('omits session_id when not provided', async () => {
+      mockScannerInstance.asyncScan.mockResolvedValue({
+        received: '2026-03-09T00:00:00Z',
+        scan_id: 'no-session',
+      });
+
+      await service.submitBulkScan('my-profile', ['test prompt']);
+      const scanObj = mockScannerInstance.asyncScan.mock.calls[0][0][0];
+      expect(scanObj.scan_req.session_id).toBeUndefined();
+    });
+
     it('handles single prompt', async () => {
       mockScannerInstance.asyncScan.mockResolvedValue({
         received: '2026-03-09T00:00:00Z',


### PR DESCRIPTION
## Summary

- `submitBulkScan()` now passes `session_id` in each async scan request for AIRS Sessions UI grouping
- CLI auto-generates a session ID per run or accepts `--session-id <id>` flag
- Session ID persisted in `.bulk-scan.json` state file

Closes #131

## Test plan

- [x] 2 new unit tests: session_id passthrough + omission when not provided
- [x] 494 total tests passing
- [x] TypeScript, lint, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)