### PR TITLE
fix: poll retry decays instead of resetting, sweep all pending per cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ tests/
 - `SdkRuntimeService` wraps SDK `Scanner` for sync and async scanning
 - `scanPrompt()` — sync scan via `syncScan()`, normalizes to `RuntimeScanResult`
 - `submitBulkScan()` — batches prompts into groups of 5 `AsyncScanObject` items, calls `asyncScan()` per batch; optional `sessionId` for AIRS Sessions UI grouping
-- `pollResults()` — polls `queryByScanIds()` every 5s until all scans COMPLETED or FAILED; retries on rate limit with exponential backoff (default 5 retries, 10s base delay)
+- `pollResults()` — sweeps all pending scan IDs in batches of 5 per cycle; retries on rate limit with exponential backoff (10s base, decay-on-success); inter-batch and inter-sweep delays scale with rate limit pressure
 - `formatResultsCsv()` — static method producing CSV from results
 - CLI: `daystrom runtime scan --profile <name> [--response <text>] <prompt>`
 - CLI: `daystrom runtime bulk-scan --profile <name> --input <file> [--output <file>] [--session-id <id>]`

--- a/docs/features/runtime-security.md
+++ b/docs/features/runtime-security.md
@@ -116,11 +116,12 @@ iteration,prompt,category,result
 
 ### Rate Limit Handling
 
-If the AIRS API returns a rate limit error during polling, Daystrom retries automatically with exponential backoff (10s, 20s, 40s, 80s, 160s). You'll see retry messages in the terminal:
+If the AIRS API returns a rate limit error during polling, Daystrom retries automatically with exponential backoff. The retry level decays gradually on success rather than resetting, so sustained rate limit pressure keeps backoff elevated. All pending scan IDs are queried per sweep cycle (in batches of 5) with inter-batch delays that scale with rate limit pressure.
 
 ```
   ⚠ Rate limited — retry 1 in 10s...
   ⚠ Rate limited — retry 2 in 20s...
+  ⚠ Rate limited — retry 3 in 40s...
 ```
 
 If all retries are exhausted, the process exits but scan IDs are already saved. Resume with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",

--- a/src/airs/runtime.ts
+++ b/src/airs/runtime.ts
@@ -106,64 +106,84 @@ export class SdkRuntimeService implements RuntimeService {
     const baseDelay = retryOpts?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
     const completed = new Map<string, RuntimeScanResult>();
     const pending = new Set(scanIds);
-    let consecutiveRetries = 0;
+    let retryLevel = 0;
 
     while (pending.size > 0) {
-      const batch = [...pending].slice(0, 5);
+      // Query all pending IDs in batches of 5 per sweep
+      const pendingIds = [...pending];
+      for (let b = 0; b < pendingIds.length; b += 5) {
+        const batch = pendingIds.slice(b, b + 5);
 
-      let results: unknown[];
-      try {
-        results = await this.scanner.queryByScanIds(batch);
-        consecutiveRetries = 0;
-      } catch (err) {
-        if (isRateLimitError(err) && consecutiveRetries < maxRetries) {
-          consecutiveRetries++;
-          const delayMs = baseDelay * 2 ** (consecutiveRetries - 1);
-          retryOpts?.onRetry?.(consecutiveRetries, delayMs);
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
-          continue;
+        let results: unknown[];
+        try {
+          results = await this.scanner.queryByScanIds(batch);
+          // Decay retry level on success (don't reset to 0)
+          if (retryLevel > 0) retryLevel = Math.max(0, retryLevel - 1);
+        } catch (err) {
+          if (isRateLimitError(err) && retryLevel < maxRetries) {
+            retryLevel++;
+            const delayMs = baseDelay * 2 ** (retryLevel - 1);
+            retryOpts?.onRetry?.(retryLevel, delayMs);
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            break; // restart sweep from the beginning
+          }
+          throw err;
         }
-        throw err;
-      }
 
-      for (const r of results as Array<Record<string, unknown>>) {
-        const id = (r.scan_id as string) ?? '';
-        const status = (r.status as string) ?? '';
+        this.processQueryResults(results, completed, pending);
 
-        if (status === 'COMPLETED' && r.result) {
-          const result = r.result as Record<string, unknown>;
-          completed.set(id, {
-            prompt: '', // not available from async API
-            response: undefined, // not available from async API
-            scanId: (result.scan_id as string) ?? id,
-            reportId: (result.report_id as string) ?? '',
-            action: result.action === 'block' ? 'block' : 'allow',
-            category: (result.category as string) ?? 'unknown',
-            triggered: false, // not available from async API — always false
-            detections: {}, // not available from async API
-          });
-          pending.delete(id);
-        } else if (status === 'FAILED') {
-          completed.set(id, {
-            prompt: '', // not available from async API
-            response: undefined, // not available from async API
-            scanId: id,
-            reportId: '',
-            action: 'allow', // safe default for failed scans
-            category: 'error',
-            triggered: false, // not available from async API — always false
-            detections: {}, // not available from async API
-          });
-          pending.delete(id);
+        // Small inter-batch delay to avoid hammering the API
+        if (b + 5 < pendingIds.length) {
+          const batchDelay = retryLevel > 0 ? baseDelay : Math.min(baseDelay, 1000);
+          await new Promise((resolve) => setTimeout(resolve, batchDelay));
         }
       }
 
       if (pending.size > 0) {
-        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        const sweepDelay = retryLevel > 0 ? baseDelay * 2 ** retryLevel : intervalMs;
+        await new Promise((resolve) => setTimeout(resolve, sweepDelay));
       }
     }
 
     return scanIds.map((id) => completed.get(id) as RuntimeScanResult);
+  }
+
+  private processQueryResults(
+    results: unknown[],
+    completed: Map<string, RuntimeScanResult>,
+    pending: Set<string>,
+  ): void {
+    for (const r of results as Array<Record<string, unknown>>) {
+      const id = (r.scan_id as string) ?? '';
+      const status = (r.status as string) ?? '';
+
+      if (status === 'COMPLETED' && r.result) {
+        const result = r.result as Record<string, unknown>;
+        completed.set(id, {
+          prompt: '', // not available from async API
+          response: undefined, // not available from async API
+          scanId: (result.scan_id as string) ?? id,
+          reportId: (result.report_id as string) ?? '',
+          action: result.action === 'block' ? 'block' : 'allow',
+          category: (result.category as string) ?? 'unknown',
+          triggered: false, // not available from async API — always false
+          detections: {}, // not available from async API
+        });
+        pending.delete(id);
+      } else if (status === 'FAILED') {
+        completed.set(id, {
+          prompt: '', // not available from async API
+          response: undefined, // not available from async API
+          scanId: id,
+          reportId: '',
+          action: 'allow', // safe default for failed scans
+          category: 'error',
+          triggered: false, // not available from async API — always false
+          detections: {}, // not available from async API
+        });
+        pending.delete(id);
+      }
+    }
   }
 
   static formatResultsCsv(results: RuntimeScanResult[]): string {

--- a/tests/unit/airs/runtime.spec.ts
+++ b/tests/unit/airs/runtime.spec.ts
@@ -315,13 +315,18 @@ describe('SdkRuntimeService', () => {
       expect(onRetry).toHaveBeenCalledWith(1, expect.any(Number));
     });
 
-    it('resets retry counter after successful poll', async () => {
+    it('decays retry counter on success instead of resetting to 0', async () => {
       const rateLimitError = new Error('Rate limit exceeded');
+      const onRetry = vi.fn();
 
+      // Rate limit twice → retry escalates to 2
+      // Then succeed → decays to 1 (not 0)
+      // Then rate limit again → retry at level 2 (1+1), not back to 1
       mockScannerInstance.queryByScanIds
-        .mockRejectedValueOnce(rateLimitError)
-        .mockResolvedValueOnce([{ scan_id: 's1', status: 'PENDING' }])
-        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError) // retry 1
+        .mockRejectedValueOnce(rateLimitError) // retry 2
+        .mockResolvedValueOnce([{ scan_id: 's1', status: 'PENDING' }]) // success, decay to 1
+        .mockRejectedValueOnce(rateLimitError) // retry 2 (decayed 1 + 1)
         .mockResolvedValueOnce([
           {
             scan_id: 's1',
@@ -330,9 +335,39 @@ describe('SdkRuntimeService', () => {
           },
         ]);
 
-      const results = await service.pollResults(['s1'], 10, { maxRetries: 2, baseDelayMs: 10 });
+      const results = await service.pollResults(['s1'], 10, {
+        maxRetries: 5,
+        baseDelayMs: 10,
+        onRetry,
+      });
       expect(results).toHaveLength(1);
-      expect(mockScannerInstance.queryByScanIds).toHaveBeenCalledTimes(4);
+      // Verify retry levels escalated: 1, 2, then after decay: 2
+      expect(onRetry).toHaveBeenCalledTimes(3);
+      expect(onRetry.mock.calls[0][0]).toBe(1); // first retry
+      expect(onRetry.mock.calls[1][0]).toBe(2); // second retry
+      expect(onRetry.mock.calls[2][0]).toBe(2); // after decay from 2→1, then +1=2
+    });
+
+    it('queries all pending IDs per sweep in batches of 5', async () => {
+      // 12 scan IDs = 3 batches of 5,5,2 per sweep
+      const ids = Array.from({ length: 12 }, (_, i) => `s${i}`);
+
+      // All complete on first sweep (3 batch queries)
+      for (let i = 0; i < 12; i += 5) {
+        const batch = ids.slice(i, i + 5);
+        mockScannerInstance.queryByScanIds.mockResolvedValueOnce(
+          batch.map((id) => ({
+            scan_id: id,
+            status: 'COMPLETED',
+            result: { scan_id: id, report_id: `r-${id}`, action: 'allow', category: 'benign' },
+          })),
+        );
+      }
+
+      const results = await service.pollResults(ids, 10, { baseDelayMs: 10 });
+      expect(results).toHaveLength(12);
+      // Should have made 3 batch queries in one sweep
+      expect(mockScannerInstance.queryByScanIds).toHaveBeenCalledTimes(3);
     });
   });
 


### PR DESCRIPTION
## Summary

- Retry level decays by 1 on success instead of resetting to 0, so sustained rate limits properly escalate backoff
- All pending scan IDs queried per sweep cycle (batched in groups of 5) instead of one batch per iteration
- Inter-batch and inter-sweep delays scale with rate limit pressure
- Extracted `processQueryResults()` helper to reduce method size

Closes #133

## Test plan

- [x] New test: retry counter decays on success, not resets
- [x] New test: all pending IDs queried per sweep in batches of 5
- [x] Updated existing retry tests for new behavior
- [x] 495 total tests passing
- [x] TypeScript, lint, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)