### PR TITLE
fix: decay poll retry level per-sweep not per-batch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ tests/
 - `SdkRuntimeService` wraps SDK `Scanner` for sync and async scanning
 - `scanPrompt()` — sync scan via `syncScan()`, normalizes to `RuntimeScanResult`
 - `submitBulkScan()` — batches prompts into groups of 5 `AsyncScanObject` items, calls `asyncScan()` per batch; optional `sessionId` for AIRS Sessions UI grouping
-- `pollResults()` — sweeps all pending scan IDs in batches of 5 per cycle; retries on rate limit with exponential backoff (10s base, decay-on-success); inter-batch and inter-sweep delays scale with rate limit pressure
+- `pollResults()` — sweeps all pending scan IDs in batches of 5 per cycle; retries on rate limit with exponential backoff (10s base); retry level decays by 1 after a full successful sweep (not per-batch); inter-batch and inter-sweep delays scale with rate limit pressure
 - `formatResultsCsv()` — static method producing CSV from results
 - CLI: `daystrom runtime scan --profile <name> [--response <text>] <prompt>`
 - CLI: `daystrom runtime bulk-scan --profile <name> --input <file> [--output <file>] [--session-id <id>]`

--- a/src/airs/runtime.ts
+++ b/src/airs/runtime.ts
@@ -111,20 +111,21 @@ export class SdkRuntimeService implements RuntimeService {
     while (pending.size > 0) {
       // Query all pending IDs in batches of 5 per sweep
       const pendingIds = [...pending];
+      let sweepCompleted = true;
+
       for (let b = 0; b < pendingIds.length; b += 5) {
         const batch = pendingIds.slice(b, b + 5);
 
         let results: unknown[];
         try {
           results = await this.scanner.queryByScanIds(batch);
-          // Decay retry level on success (don't reset to 0)
-          if (retryLevel > 0) retryLevel = Math.max(0, retryLevel - 1);
         } catch (err) {
           if (isRateLimitError(err) && retryLevel < maxRetries) {
             retryLevel++;
             const delayMs = baseDelay * 2 ** (retryLevel - 1);
             retryOpts?.onRetry?.(retryLevel, delayMs);
             await new Promise((resolve) => setTimeout(resolve, delayMs));
+            sweepCompleted = false;
             break; // restart sweep from the beginning
           }
           throw err;
@@ -137,6 +138,11 @@ export class SdkRuntimeService implements RuntimeService {
           const batchDelay = retryLevel > 0 ? baseDelay : Math.min(baseDelay, 1000);
           await new Promise((resolve) => setTimeout(resolve, batchDelay));
         }
+      }
+
+      // Only decay retry level after a full sweep with no rate limit errors
+      if (sweepCompleted && retryLevel > 0) {
+        retryLevel = Math.max(0, retryLevel - 1);
       }
 
       if (pending.size > 0) {

--- a/tests/unit/airs/runtime.spec.ts
+++ b/tests/unit/airs/runtime.spec.ts
@@ -315,25 +315,25 @@ describe('SdkRuntimeService', () => {
       expect(onRetry).toHaveBeenCalledWith(1, expect.any(Number));
     });
 
-    it('decays retry counter on success instead of resetting to 0', async () => {
+    it('decays retry level after a full successful sweep, not per-batch', async () => {
       const rateLimitError = new Error('Rate limit exceeded');
       const onRetry = vi.fn();
 
-      // Rate limit twice → retry escalates to 2
-      // Then succeed → decays to 1 (not 0)
-      // Then rate limit again → retry at level 2 (1+1), not back to 1
+      // Single scan ID — each sweep = 1 batch
+      // Rate limit twice → level escalates to 2
+      // Then full sweep succeeds (PENDING) → decay to 1
+      // Then full sweep succeeds (COMPLETE) → decay to 0, done
       mockScannerInstance.queryByScanIds
         .mockRejectedValueOnce(rateLimitError) // retry 1
         .mockRejectedValueOnce(rateLimitError) // retry 2
-        .mockResolvedValueOnce([{ scan_id: 's1', status: 'PENDING' }]) // success, decay to 1
-        .mockRejectedValueOnce(rateLimitError) // retry 2 (decayed 1 + 1)
+        .mockResolvedValueOnce([{ scan_id: 's1', status: 'PENDING' }]) // sweep ok, decay 2→1
         .mockResolvedValueOnce([
           {
             scan_id: 's1',
             status: 'COMPLETED',
             result: { scan_id: 's1', report_id: 'r1', action: 'allow', category: 'benign' },
           },
-        ]);
+        ]); // sweep ok, decay 1→0
 
       const results = await service.pollResults(['s1'], 10, {
         maxRetries: 5,
@@ -341,11 +341,52 @@ describe('SdkRuntimeService', () => {
         onRetry,
       });
       expect(results).toHaveLength(1);
-      // Verify retry levels escalated: 1, 2, then after decay: 2
-      expect(onRetry).toHaveBeenCalledTimes(3);
-      expect(onRetry.mock.calls[0][0]).toBe(1); // first retry
-      expect(onRetry.mock.calls[1][0]).toBe(2); // second retry
-      expect(onRetry.mock.calls[2][0]).toBe(2); // after decay from 2→1, then +1=2
+      expect(onRetry).toHaveBeenCalledTimes(2);
+      expect(onRetry.mock.calls[0][0]).toBe(1);
+      expect(onRetry.mock.calls[1][0]).toBe(2);
+    });
+
+    it('does not decay retry level when early batches succeed but later ones fail', async () => {
+      const rateLimitError = new Error('Rate limit exceeded');
+      const onRetry = vi.fn();
+
+      // 10 scan IDs = 2 batches per sweep
+      const ids = ['s0', 's1', 's2', 's3', 's4', 's5', 's6', 's7', 's8', 's9'];
+
+      // Sweep 1: batch 1 succeeds (all pending), batch 2 rate-limits → level 1
+      mockScannerInstance.queryByScanIds
+        .mockResolvedValueOnce(ids.slice(0, 5).map((id) => ({ scan_id: id, status: 'PENDING' })))
+        .mockRejectedValueOnce(rateLimitError) // level → 1
+        // Sweep 2: batch 1 succeeds (all pending), batch 2 rate-limits → level 2
+        .mockResolvedValueOnce(ids.slice(0, 5).map((id) => ({ scan_id: id, status: 'PENDING' })))
+        .mockRejectedValueOnce(rateLimitError) // level → 2
+        // Sweep 3: both batches succeed → all complete
+        .mockResolvedValueOnce(
+          ids.slice(0, 5).map((id) => ({
+            scan_id: id,
+            status: 'COMPLETED',
+            result: { scan_id: id, report_id: `r-${id}`, action: 'allow', category: 'benign' },
+          })),
+        )
+        .mockResolvedValueOnce(
+          ids.slice(5).map((id) => ({
+            scan_id: id,
+            status: 'COMPLETED',
+            result: { scan_id: id, report_id: `r-${id}`, action: 'allow', category: 'benign' },
+          })),
+        );
+
+      const results = await service.pollResults(ids, 10, {
+        maxRetries: 5,
+        baseDelayMs: 10,
+        onRetry,
+      });
+
+      expect(results).toHaveLength(10);
+      // Key assertion: retry must escalate to 2, not stay at 1
+      expect(onRetry).toHaveBeenCalledTimes(2);
+      expect(onRetry.mock.calls[0][0]).toBe(1);
+      expect(onRetry.mock.calls[1][0]).toBe(2); // must be 2, not 1
     });
 
     it('queries all pending IDs per sweep in batches of 5', async () => {


### PR DESCRIPTION
## Summary

- Retry level was decaying per-batch-success **within** a sweep, causing it to oscillate 0↔1 forever when early batches succeeded but later ones hit rate limits
- Moved decay to after a **full successful sweep** (no rate limit errors)
- Updated existing decay test to match sweep-level semantics
- Added new test: multi-batch sweep where early batches succeed but later ones fail — verifies level escalates

Closes #135

## Test plan

- [x] New test: multi-batch sweep with partial rate limit — level must escalate
- [x] Updated decay test for sweep-level semantics
- [x] All 496 tests pass
- [x] tsc, biome lint, biome format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)