### PR TITLE
fix: bypass SDK JSON.parse for CSV template download (#143)

### DIFF
--- a/src/airs/promptsets.ts
+++ b/src/airs/promptsets.ts
@@ -104,8 +104,25 @@ export class SdkPromptSetService implements PromptSetService {
   }
 
   async downloadTemplate(uuid: string): Promise<string> {
-    const response = await this.client.customAttacks.downloadTemplate(uuid);
-    return response as unknown as string;
+    // Bypass SDK's downloadTemplate — it routes through managementHttpRequest
+    // which unconditionally JSON.parse()s the response, but this endpoint
+    // returns text/csv. Make a raw fetch using the SDK's OAuth client instead.
+    const internals = this.client.customAttacks as unknown as {
+      baseUrl: string;
+      oauthClient: { getToken(): Promise<string> };
+    };
+    const token = await internals.oauthClient.getToken();
+    const base = internals.baseUrl.replace(/\/+$/, '');
+    const url = `${base}/v1/custom-attack/download-template/${uuid}`;
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Download template failed (${res.status}): ${body}`);
+    }
+    return res.text();
   }
 
   async uploadPromptsCsv(uuid: string, file: Blob): Promise<{ message: string; status: number }> {

--- a/tests/unit/airs/promptsets.spec.ts
+++ b/tests/unit/airs/promptsets.spec.ts
@@ -22,6 +22,8 @@ const mockCreatePropertyValue = vi.fn();
 vi.mock('@cdot65/prisma-airs-sdk', () => ({
   RedTeamClient: vi.fn().mockImplementation(() => ({
     customAttacks: {
+      baseUrl: 'https://api.example.com',
+      oauthClient: { getToken: vi.fn().mockResolvedValue('mock-token') },
       createPromptSet: mockCreatePromptSet,
       createPrompt: mockCreatePrompt,
       listPromptSets: mockListPromptSets,
@@ -259,11 +261,36 @@ describe('SdkPromptSetService', () => {
   });
 
   describe('downloadTemplate', () => {
-    it('returns CSV template string', async () => {
-      mockDownloadTemplate.mockResolvedValue('prompt,goal\n"test","test goal"');
+    it('returns CSV template string via raw fetch', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('prompt,goal\n"test","test goal"'),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
       const result = await service.downloadTemplate('ps-1');
       expect(result).toBe('prompt,goal\n"test","test goal"');
-      expect(mockDownloadTemplate).toHaveBeenCalledWith('ps-1');
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/v1/custom-attack/download-template/ps-1'),
+        expect.objectContaining({ method: 'GET' }),
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('throws on non-OK response', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('Not found'),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await expect(service.downloadTemplate('ps-1')).rejects.toThrow(
+        'Download template failed (404)',
+      );
+
+      vi.unstubAllGlobals();
     });
   });
 


### PR DESCRIPTION
## Summary
- `daystrom redteam prompt-sets download` failed with JSON parse error on CSV response
- SDK's `managementHttpRequest` unconditionally `JSON.parse()`s all responses
- Bypassed SDK method with raw `fetch` using OAuth token from SDK client internals

## Changes
- `src/airs/promptsets.ts`: `downloadTemplate()` makes raw HTTP request instead of calling SDK
- `tests/unit/airs/promptsets.spec.ts`: Updated mock to expose `baseUrl`/`oauthClient`, test validates fetch call and error handling

## Testing
- 500 tests pass (1 new error-path test added)
- Lint, format, typecheck all clean

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)