### PR TITLE
chore: bump version to 1.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Patch bump 1.12.2 → 1.12.3 for CSV download fix (#143)

🤖 Generated with [Claude Code](https://claude.com/claude-code)