### PR TITLE
chore: bump version to 1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Minor bump 1.12.3 → 1.13.0 for --save-tests feature (#146)

🤖 Generated with [Claude Code](https://claude.com/claude-code)