### PR TITLE
fix: use prompt_detected.topic_violation as sole detection signal (#149)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,14 +101,14 @@ src/
 └── index.ts               # Library exports
 
 tests/
-├── unit/                  # 27 spec files
+├── unit/                  # 28 spec files
 │   ├── airs/              # scanner.spec.ts, management.spec.ts, modelsecurity.spec.ts, promptsets.spec.ts, redteam.spec.ts, runtime.spec.ts
 │   ├── audit/             # evaluator.spec.ts, runner.spec.ts, report.spec.ts
 │   ├── cli/               # parse-input.spec.ts, bulk-scan-state.spec.ts
 │   ├── config/            # schema.spec.ts, loader.spec.ts
 │   ├── core/              # loop.spec.ts, metrics.spec.ts, constraints.spec.ts
 │   ├── llm/               # provider.spec.ts, schemas.spec.ts, service.spec.ts, prompts.spec.ts
-│   ├── memory/            # store.spec.ts, extractor.spec.ts, injector.spec.ts, diff.spec.ts
+│   ├── memory/            # store.spec.ts, extractor.spec.ts, injector.spec.ts, diff.spec.ts, prompts.spec.ts
 │   ├── persistence/       # store.spec.ts
 │   └── report/            # json.spec.ts, html.spec.ts
 ├── integration/           # loop.integration.spec.ts (full loop w/ mocks)
@@ -137,8 +137,8 @@ tests/
 - **Description simplification**: After 2 consecutive regressions, if `hasTriedSimplification` is false and a best iteration exists, the loop calls `simplifyTopic()` to strip exclusion clauses and shorten the description. Resets regression counter to 0. Only attempted once per run (`RunState.hasTriedSimplification`). If simplification also regresses, early stopping kicks in at `maxRegressions`.
 
 ### AIRS Integration (`src/airs/`)
-- **Scanner**: `Scanner.syncScan()` via SDK, detection = `prompt_detected.topic_violation` (fallback: `topic_guardrails_details`), extracts `category` from response
-- **Allow-intent detection via `category`**: For allow topics, AIRS never sets `triggered: true` and `action` is unreliable. The loop uses `category === 'benign'` (topic matched) vs `'malicious'` (no match), falling back to `triggered` when `category` is absent
+- **Scanner**: `Scanner.syncScan()` via SDK, detection = `prompt_detected.topic_violation === true` (sole signal, no fallbacks). `category` still extracted for weighted test generation but not used for detection
+- **Detection**: Both block and allow intents use `triggered` (= `topic_violation`) as the sole guardrail detection signal. No category-based or action-based detection.
 - **`DebugScanService`**: Wrapper that appends raw scan responses to a JSONL file when `--debug-scans` is passed
 - **Prompt sets**: `SdkPromptSetService` wraps `RedTeamClient.customAttacks` for custom prompt set CRUD; `--create-prompt-set` auto-creates a prompt set from the best iteration's test cases
 - **Management**: `ManagementClient` for topic CRUD + profile linking via OAuth2
@@ -213,7 +213,7 @@ tests/
 ### Audit (`src/audit/`)
 - `runAudit()` async generator yields `AuditEvent` discriminated union: `topics:loaded`, `tests:generated`, `scan:progress`, `evaluate:complete`, `audit:complete`
 - Reads all topics from profile via `getProfileTopics()`, generates tests per topic (tagged with `targetTopic`), batch scans, evaluates per-topic + composite metrics
-- Allow-intent detection uses `category === 'benign'` (topic matched); block uses `triggered`
+- Both intents use `triggered` (= `prompt_detected.topic_violation`) as sole detection signal
 - `detectConflicts()` finds FN/FP overlaps between topic pairs — same prompt failing as FN for topic A and FP for topic B
 - `getProfileTopics()` reads profile policy `model-protection → topic-guardrails → topic-list`, cross-references with `listTopics()` for full details
 

--- a/src/airs/scanner.ts
+++ b/src/airs/scanner.ts
@@ -23,7 +23,7 @@ export class AirsScanService implements ScanService {
 
     const action = response.action === 'block' ? 'block' : 'allow';
     const detected = response.prompt_detected as Record<string, unknown> | undefined;
-    const triggered = !!(detected?.topic_guardrails_details || detected?.topic_violation);
+    const triggered = detected?.topic_violation === true;
     const category = (response.category as string) ?? undefined;
 
     return {

--- a/src/audit/runner.ts
+++ b/src/audit/runner.ts
@@ -64,13 +64,8 @@ export async function* runAudit(
   // 4. Build test results
   const testResults: TestResult[] = allTests.map((testCase, i) => {
     const scan = scanResults[i];
-    const targetTopic = topics.find((t) => t.topicName === testCase.targetTopic);
-    let actualTriggered: boolean;
-    if (targetTopic?.action === 'allow' && scan.category) {
-      actualTriggered = scan.category === 'benign';
-    } else {
-      actualTriggered = scan.triggered;
-    }
+    // prompt_detected.topic_violation is the sole signal for both intents.
+    const actualTriggered = scan.triggered;
     return {
       testCase,
       actualTriggered,

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -301,12 +301,7 @@ export async function* runLoop(
           `daystrom-${runState.id.slice(0, 7)}-probe`,
         );
 
-        let matched: boolean;
-        if (input.intent === 'allow' && probeResult.category) {
-          matched = probeResult.category === 'benign';
-        } else {
-          matched = probeResult.triggered;
-        }
+        const matched = probeResult.triggered;
 
         if (matched) {
           yield { type: 'probe:ready' as const, attempts: attempt };
@@ -420,16 +415,8 @@ export async function* runLoop(
     for (let j = 0; j < allTests.length; j++) {
       const testCase = allTests[j];
       const scanResult = scanResults[j];
-      // Derive whether the topic guardrail matched this prompt.
-      // For allow intent: AIRS never sets triggered=true; use category field instead
-      // ("benign" = matched the allow topic, "malicious" = did not match).
-      // For block intent: use the triggered flag directly.
-      let actualTriggered: boolean;
-      if (input.intent === 'allow' && scanResult.category) {
-        actualTriggered = scanResult.category === 'benign';
-      } else {
-        actualTriggered = scanResult.triggered;
-      }
+      // prompt_detected.topic_violation is the sole signal for both intents.
+      const actualTriggered = scanResult.triggered;
       testResults.push({
         testCase,
         actualTriggered,

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -108,9 +108,9 @@ export function createMockScanService(
 
 /**
  * Mock scanner simulating AIRS allow-intent behavior.
- * Matching prompts → category: 'benign' (content matched the allow topic).
- * Non-matching prompts → category: 'malicious' (content not in allowed set).
- * triggered is always false for allow topics; action is always 'allow'.
+ * Matching prompts → topic_violation: true (topic guardrail matched).
+ * Non-matching prompts → topic_violation: false (not matched).
+ * Uses triggered (= topic_violation) as sole detection signal.
  */
 export function createMockAllowScanService(allowPatterns: RegExp[] = []): ScanService {
   return {
@@ -120,7 +120,7 @@ export function createMockAllowScanService(allowPatterns: RegExp[] = []): ScanSe
         scanId: `scan-${Date.now()}`,
         reportId: `report-${Date.now()}`,
         action: 'allow',
-        triggered: false, // AIRS never sets topic_violation for allow-intent topics
+        triggered: matches,
         category: matches ? 'benign' : 'malicious',
       };
     },
@@ -137,7 +137,7 @@ export function createMockAllowScanService(allowPatterns: RegExp[] = []): ScanSe
           scanId: `scan-${Date.now()}`,
           reportId: `report-${Date.now()}`,
           action: 'allow',
-          triggered: false,
+          triggered: matches,
           category: matches ? 'benign' : 'malicious',
         });
       }

--- a/tests/unit/airs/scanner.spec.ts
+++ b/tests/unit/airs/scanner.spec.ts
@@ -26,13 +26,13 @@ describe('AirsScanService', () => {
   });
 
   describe('scan', () => {
-    it('returns blocked result when topic guardrail triggers', async () => {
+    it('returns blocked result when topic_violation is true', async () => {
       mockSyncScan.mockResolvedValue({
         scan_id: 'scan-123',
         report_id: 'report-456',
         action: 'block',
         prompt_detected: {
-          topic_guardrails_details: true,
+          topic_violation: true,
         },
       });
 
@@ -41,6 +41,18 @@ describe('AirsScanService', () => {
       expect(result.reportId).toBe('report-456');
       expect(result.action).toBe('block');
       expect(result.triggered).toBe(true);
+    });
+
+    it('does not trigger on topic_guardrails_details alone', async () => {
+      mockSyncScan.mockResolvedValue({
+        scan_id: 's1',
+        report_id: 'r1',
+        action: 'block',
+        prompt_detected: { topic_guardrails_details: true },
+      });
+
+      const result = await service.scan('my-profile', 'test');
+      expect(result.triggered).toBe(false);
     });
 
     it('returns allowed result when not triggered', async () => {
@@ -144,7 +156,7 @@ describe('AirsScanService', () => {
           scan_id: 's1',
           report_id: 'r1',
           action: 'block',
-          prompt_detected: { topic_guardrails_details: true },
+          prompt_detected: { topic_violation: true },
         })
         .mockResolvedValueOnce({
           scan_id: 's2',

--- a/tests/unit/audit/runner.spec.ts
+++ b/tests/unit/audit/runner.spec.ts
@@ -136,21 +136,21 @@ describe('runAudit', () => {
     }
   });
 
-  it('uses allow-intent detection for allow topics', async () => {
+  it('uses triggered (topic_violation) for allow topics', async () => {
     const allowScanner = {
       scan: async (): Promise<ScanResult> => ({
         scanId: 'scan-1',
         reportId: 'report-1',
         action: 'allow' as const,
-        triggered: false,
-        category: 'benign', // matched allow topic
+        triggered: true, // topic_violation: true
+        category: 'benign',
       }),
       scanBatch: async (_p: string, prompts: string[]): Promise<ScanResult[]> =>
         prompts.map(() => ({
           scanId: 'scan-1',
           reportId: 'report-1',
           action: 'allow' as const,
-          triggered: false,
+          triggered: true,
           category: 'benign',
         })),
     };
@@ -166,7 +166,7 @@ describe('runAudit', () => {
       const positiveTest = complete.result.topics[0].testResults.find(
         (r) => r.testCase.expectedTriggered,
       );
-      // category=benign means allow topic matched → actualTriggered=true
+      // triggered=true (topic_violation) → actualTriggered=true
       expect(positiveTest?.actualTriggered).toBe(true);
     }
   });

--- a/tests/unit/core/loop.spec.ts
+++ b/tests/unit/core/loop.spec.ts
@@ -411,8 +411,8 @@ describe('runLoop', () => {
     );
   });
 
-  it('uses category field for allow-intent triggered detection', async () => {
-    // Mock scanner simulating AIRS allow-intent: matching prompts → category: 'benign'
+  it('uses topic_violation (triggered) for allow-intent detection', async () => {
+    // Mock scanner: matching prompts → triggered: true (topic_violation)
     const allowScanner = createMockAllowScanService([/weapon/i, /bomb/i]);
     const llm = createMockLlm();
     const deps = createDeps({ llm, scanner: allowScanner });
@@ -428,15 +428,15 @@ describe('runLoop', () => {
     const evalEvent = events.find((e) => e.type === 'evaluate:complete');
     expect(evalEvent).toBeDefined();
     if (evalEvent?.type === 'evaluate:complete') {
-      // "weapon" and "bomb" prompts → category: 'benign' → actualTriggered = true
-      // "cats" and "weather" → category: 'malicious' → actualTriggered = false
+      // "weapon" and "bomb" prompts → triggered: true → actualTriggered = true
+      // "cats" and "weather" → triggered: false → actualTriggered = false
       expect(evalEvent.metrics.truePositives).toBeGreaterThan(0);
       expect(evalEvent.metrics.trueNegatives).toBeGreaterThan(0);
     }
   });
 
-  it('falls back to triggered when category absent for allow-intent', async () => {
-    // Scanner with no category field — should fall back to triggered
+  it('allow-intent with no triggered yields false negatives', async () => {
+    // Scanner with triggered always false — all positives become FN
     const noCategoryScanner: import('../../../src/airs/types.js').ScanService = {
       scan: async () => ({
         scanId: 's1',
@@ -465,7 +465,7 @@ describe('runLoop', () => {
     const evalEvent = events.find((e) => e.type === 'evaluate:complete');
     expect(evalEvent).toBeDefined();
     if (evalEvent?.type === 'evaluate:complete') {
-      // All triggered=false, so all actualTriggered=false → positive tests are FN
+      // All triggered=false → positive tests are FN
       expect(evalEvent.metrics.falseNegatives).toBeGreaterThan(0);
     }
   });
@@ -1966,18 +1966,18 @@ describe('runLoop', () => {
       expect(probeEvents).toHaveLength(0);
     });
 
-    it('uses category === benign for allow-intent probe', async () => {
+    it('uses triggered (topic_violation) for allow-intent probe', async () => {
       let probeScanCount = 0;
       const scanner: ScanService = {
         scan: async (_profile: string, _prompt: string) => {
           probeScanCount++;
-          // First probe: category malicious (not matched). Second: category benign (matched).
+          // First probe: not matched. Second: matched via topic_violation.
           const matched = probeScanCount >= 2;
           return {
             scanId: `scan-${probeScanCount}`,
             reportId: `report-${probeScanCount}`,
             action: 'allow' as const,
-            triggered: false, // AIRS never sets triggered for allow-intent
+            triggered: matched,
             category: matched ? 'benign' : 'malicious',
           };
         },


### PR DESCRIPTION
## Summary
- Replace multi-field guardrail detection with `prompt_detected.topic_violation === true` as sole signal
- Remove category-based allow-intent detection (`category === 'benign'` workaround)
- Remove `topic_guardrails_details` fallback from scanner
- Both block and allow intents now use `triggered` uniformly

## Changes
- `src/airs/scanner.ts`: `triggered = detected?.topic_violation === true`
- `src/core/loop.ts`: Remove intent-conditional detection branch (probe + test eval)
- `src/audit/runner.ts`: Remove intent-conditional detection branch
- `tests/helpers/mocks.ts`: `createMockAllowScanService` now sets `triggered` based on match
- Tests updated across scanner, loop, audit runner
- CLAUDE.md updated to reflect new detection logic

## Testing
- 501 tests pass (1 new: `topic_guardrails_details` alone does not trigger)
- Lint, format, typecheck all clean

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)