### PR TITLE
fix: save-tests falls back to last iteration when bestIteration is 0

### DIFF
--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -237,7 +237,11 @@ export function registerGenerateCommand(program: Command): void {
               await store.save(event.runState);
               renderLoopComplete(event.runState);
               if (opts.saveTests) {
-                const best = event.runState.iterations[event.runState.bestIteration - 1];
+                const bestIdx =
+                  event.runState.bestIteration > 0
+                    ? event.runState.bestIteration - 1
+                    : event.runState.iterations.length - 1;
+                const best = event.runState.iterations[bestIdx];
                 if (best) {
                   const resultMap = new Map(best.testResults.map((r) => [r.testCase.prompt, r]));
                   const csvRows = [


### PR DESCRIPTION
## Summary
- When all iterations have 0% coverage, `bestIteration` stays at 0
- `iterations[0 - 1]` = `iterations[-1]` = `undefined` → CSV never written
- Now falls back to last iteration so the user always gets their test data

## Testing
- 501 tests pass, all gates clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)