### PR TITLE
feat: --set-profile-allow flag to test guardrail default action

### DIFF
--- a/src/airs/management.ts
+++ b/src/airs/management.ts
@@ -56,6 +56,7 @@ export class SdkManagementService implements ManagementService {
   async assignTopicsToProfile(
     profileName: string,
     topics: Array<{ topicId: string; topicName: string; action: 'allow' | 'block' }>,
+    guardrailAction?: 'allow' | 'block',
   ): Promise<void> {
     // Find profile by name
     const { ai_profiles } = await this.client.profiles.list();
@@ -85,9 +86,10 @@ export class SdkManagementService implements ManagementService {
       modelProtection.push(topicGuardrails);
     }
 
-    // Ensure the guardrail-level action is always 'block' so violations are enforced.
-    // The allow/block distinction is controlled by which topic-list entry the topic is in.
-    topicGuardrails.action = 'block';
+    // Guardrail-level action controls default behavior for topic-guardrails layer.
+    // 'block' = block all unless explicitly allowed (requires allow topics).
+    // 'allow' = allow all unless explicitly blocked (only block topics needed).
+    topicGuardrails.action = guardrailAction ?? 'block';
 
     // Group topics by action, build topic-list entries (skip empty groups).
     const byAction = new Map<string, Array<{ topic_id: string; topic_name: string }>>();

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -671,6 +671,7 @@ export interface ManagementService {
   assignTopicsToProfile(
     profileName: string,
     topics: Array<{ topicId: string; topicName: string; action: 'allow' | 'block' }>,
+    guardrailAction?: 'allow' | 'block',
   ): Promise<void>;
   /** List all topics configured in a profile with full details. */
   getProfileTopics(profileName: string): Promise<ProfileTopic[]>;

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -59,6 +59,11 @@ export function registerGenerateCommand(program: Command): void {
     .option('--create-prompt-set', 'Create custom prompt set from test cases after loop', false)
     .option('--prompt-set-name <name>', 'Override auto-generated prompt set name')
     .option('--save-tests <path>', 'Save best iteration test cases to CSV')
+    .option(
+      '--set-profile-allow',
+      "Set topic-guardrails default to 'allow' (skip companion topic, only block-topic matches blocked)",
+      false,
+    )
     .action(async (opts) => {
       try {
         renderHeader();
@@ -87,6 +92,7 @@ export function registerGenerateCommand(program: Command): void {
               : undefined,
             createPromptSet: opts.createPromptSet ?? false,
             promptSetName: opts.promptSetName,
+            setProfileAllow: opts.setProfileAllow ?? false,
           };
         } else {
           userInput = await collectUserInput();

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -267,9 +267,14 @@ export async function* runLoop(
         topicId = response.topic_id;
       }
 
-      // Two-phase: generate companion allow topic for block-intent profiles.
-      // AIRS requires a non-empty allow list when default action is "block".
-      if (input.intent === 'block') {
+      // Determine guardrail-level action.
+      // --set-profile-allow: guardrail default is 'allow', only block-topic matches get blocked.
+      // Without it: guardrail default is 'block', requires companion allow topic.
+      const guardrailAction = input.setProfileAllow ? 'allow' : 'block';
+
+      if (input.intent === 'block' && !input.setProfileAllow) {
+        // Two-phase: generate companion allow topic for block-intent profiles.
+        // AIRS requires a non-empty allow list when guardrail action is "block".
         companionTopic = await deps.llm.generateCompanionTopic(topic.name, topic.description);
         yield { type: 'companion:generated', topic: companionTopic };
 
@@ -299,17 +304,20 @@ export async function* runLoop(
         runState.companionTopic = companionTopic;
 
         // Wire both topics to profile
-        await deps.management.assignTopicsToProfile(input.profileName, [
-          { topicId: companionTopicId, topicName: companionTopic.name, action: 'allow' },
-          { topicId, topicName: topic.name, action: 'block' },
-        ]);
-      } else {
-        // Allow-intent: single topic, no companion needed
-        await deps.management.assignTopicToProfile(
+        await deps.management.assignTopicsToProfile(
           input.profileName,
-          topicId,
-          topic.name,
-          input.intent,
+          [
+            { topicId: companionTopicId, topicName: companionTopic.name, action: 'allow' },
+            { topicId, topicName: topic.name, action: 'block' },
+          ],
+          guardrailAction,
+        );
+      } else {
+        // --set-profile-allow or allow-intent: single topic, no companion needed.
+        await deps.management.assignTopicsToProfile(
+          input.profileName,
+          [{ topicId, topicName: topic.name, action: input.intent }],
+          guardrailAction,
         );
       }
     } else {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -28,6 +28,8 @@ export interface UserInput {
   maxAccumulatedTests?: number;
   createPromptSet?: boolean;
   promptSetName?: string;
+  /** Set topic-guardrails default action to 'allow' instead of 'block'. */
+  setProfileAllow?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/airs/management.spec.ts
+++ b/tests/unit/airs/management.spec.ts
@@ -541,7 +541,7 @@ describe('SdkManagementService', () => {
       expect(blockEntry?.topic).toEqual([{ topic_id: 'block-1', topic_name: 'Weapons' }]);
     });
 
-    it('always sets guardrail-level action to block', async () => {
+    it('defaults guardrail-level action to block', async () => {
       mockProfileList.mockResolvedValue({
         ai_profiles: [
           { profile_id: 'p-1', profile_name: 'test-profile', active: true, policy: {} },
@@ -555,6 +555,24 @@ describe('SdkManagementService', () => {
 
       const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
       expect((tg as Record<string, unknown>).action).toBe('block');
+    });
+
+    it('sets guardrail-level action to allow when specified', async () => {
+      mockProfileList.mockResolvedValue({
+        ai_profiles: [
+          { profile_id: 'p-1', profile_name: 'test-profile', active: true, policy: {} },
+        ],
+      });
+      mockProfileUpdate.mockResolvedValue({});
+
+      await service.assignTopicsToProfile(
+        'test-profile',
+        [{ topicId: 'block-1', topicName: 'Weapons', action: 'block' }],
+        'allow',
+      );
+
+      const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
+      expect((tg as Record<string, unknown>).action).toBe('allow');
     });
   });
 

--- a/tests/unit/core/loop.spec.ts
+++ b/tests/unit/core/loop.spec.ts
@@ -397,7 +397,7 @@ describe('runLoop', () => {
     expect(companionEvents).toHaveLength(0);
   });
 
-  it('calls assignTopicsToProfile with both topics for block intent', async () => {
+  it('calls assignTopicsToProfile with both topics for block intent (default)', async () => {
     const management = createMockManagementService();
     const assignTopicsSpy = vi.spyOn(management, 'assignTopicsToProfile');
     const deps = createDeps({ management });
@@ -406,10 +406,41 @@ describe('runLoop', () => {
       // consume
     }
 
-    expect(assignTopicsSpy).toHaveBeenCalledWith('test-profile', [
-      expect.objectContaining({ action: 'allow', topicName: 'Allow: General Content' }),
-      expect.objectContaining({ action: 'block', topicName: 'Weapons Discussion' }),
-    ]);
+    expect(assignTopicsSpy).toHaveBeenCalledWith(
+      'test-profile',
+      [
+        expect.objectContaining({ action: 'allow', topicName: 'Allow: General Content' }),
+        expect.objectContaining({ action: 'block', topicName: 'Weapons Discussion' }),
+      ],
+      'block',
+    );
+  });
+
+  it('--set-profile-allow skips companion and sets guardrailAction to allow', async () => {
+    const management = createMockManagementService();
+    const assignTopicsSpy = vi.spyOn(management, 'assignTopicsToProfile');
+    const deps = createDeps({ management });
+    const events: LoopEvent[] = [];
+
+    for await (const event of runLoop(
+      { ...defaultInput, setProfileAllow: true, maxIterations: 1 },
+      deps,
+    )) {
+      events.push(event);
+    }
+
+    // No companion events
+    const companionEvents = events.filter(
+      (e) => e.type === 'companion:generated' || e.type === 'companion:created',
+    );
+    expect(companionEvents).toHaveLength(0);
+
+    // Single block topic with guardrailAction 'allow'
+    expect(assignTopicsSpy).toHaveBeenCalledWith(
+      'test-profile',
+      [expect.objectContaining({ action: 'block', topicName: 'Weapons Discussion' })],
+      'allow',
+    );
   });
 
   it('persists companionTopic in RunState', async () => {


### PR DESCRIPTION
## Summary
- Adds `--set-profile-allow` flag to `daystrom generate`
- When set: `topicGuardrails.action = 'allow'` (default: let content through, only block-topic matches blocked)
- When unset: existing behavior (`topicGuardrails.action = 'block'` + companion allow topic)
- Skips companion allow topic generation when `--set-profile-allow` is set (not needed)

## Purpose
Testing whether `topicGuardrails.action = 'block'` is the root cause of 0% TNR. Debug scans show ALL 41 prompts return `topic_violation: true` including completely unrelated content (chocolate chip cookies, photosynthesis). Hypothesis: the guardrail-level action acts as default behavior — 'block' blocks everything not explicitly allowed.

## Test
```bash
# Without flag (existing behavior, 0% TNR)
daystrom generate --profile "Custom Topics Test" --topic "Tax Evasion" --max-iterations 1

# With flag (test hypothesis)
daystrom generate --profile "Custom Topics Test" --topic "Tax Evasion" --max-iterations 1 --set-profile-allow --debug-scans
```

## Test plan
- [x] 516 tests pass (2 new)
- [x] Lint, format, type-check clean
- [ ] Manual: run with `--set-profile-allow` and compare TNR

🤖 Generated with [Claude Code](https://claude.com/claude-code)