### PR TITLE
fix: include topic revision in profile updates for correct AIRS matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ tests/
 - Events defined in `LoopEvent` union but **not yielded** by `runLoop()`: `loop:paused` (reserved for future use), `memory:loaded` (emitted by CLI before loop starts)
 - `apply:complete` is yielded but intentionally unhandled in CLI commands (no user-facing output needed)
 - **Warm-up probe** (iter 1 only): after propagation delay, scans `topic.examples[0]` via `scanner.scan()` in a retry loop (default 6 attempts, 5s interval) to verify topic+profile revision are active before full test suite. Skipped if topic has no examples. Configurable via `LoopDependencies.probeIntervalMs` and `maxProbeAttempts`
-- **Two-phase generation** (block-intent only): AIRS requires a non-empty allow topic list when default action is "block". On iter 1, after generating the block topic, the loop generates a broad companion allow topic via `LlmService.generateCompanionTopic()`, creates it via management API, and wires both to the profile via `assignTopicsToProfile()`. The companion is one-shot (no refinement). Iter 2+ only updates the block topic content — profile references stay valid. `RunState.companionTopic` persists the companion for reporting. Allow-intent runs skip this entirely.
+- **Two-phase generation** (block-intent only): AIRS needs BOTH allow and block topics sharing the same vocabulary domain. On iter 1, generates a domain-specific allow companion via `LlmService.generateCompanionTopic()` that covers the benign/legitimate side of the same domain (e.g., "Legal Tax Planning" as companion to "Tax Evasion"). Wires both to profile with `guardrailAction='allow'` (default: allow everything, block topic carves out violations). Companion is one-shot (no refinement). Iter 2+ only updates block topic content. Allow-intent runs use `guardrailAction='block'` with a single topic.
 - Topic name **locked after iteration 1** — only description+examples change thereafter
 - `analyzeResults()` and `improveTopic()` receive intent param — prioritizes FN for block, FP for allow
 - **Test composition** (always-on, iter 2+): carried FP/FN failures + regression tier (TP/TN re-scanned) + fresh LLM tests. `TestCase.source` tags each test's origin. `EfficacyMetrics.regressionCount` tracks regression-tier failures.
@@ -146,10 +146,11 @@ tests/
 - Profile updates create **new revisions with new UUIDs** — always reference profiles by name, never ID
 - Topics must be added to profile's `model-protection` → `topic-guardrails` → `topic-list`
 - AIRS rejects empty `topic-list` entries — only include entries with topics (no empty opposite-action entry)
-- **Block-intent requires allow topic**: AIRS profiles with `default action: block` need a non-empty allow topic list. `assignTopicsToProfile()` wires both the block topic and a companion allow topic; `assignTopicToProfile()` delegates to it for single-topic compat.
-- Guardrail-level `action` must always be `'block'` to enforce violations
+- **Block-intent requires domain-specific allow topic**: AIRS needs BOTH allow and block topics sharing the same vocabulary domain. `assignTopicsToProfile()` wires both with `guardrailAction='allow'` for block-intent (default: allow everything, block topics carve out violations). Allow-intent uses `guardrailAction='block'`.
+- **CRITICAL: topic-list `revision` field**: AIRS pins topic content to the `revision` number in the profile's topic-list. Omitting it defaults to revision 0 (original creation content). `assignTopicsToProfile()` fetches current topic revisions via `listTopics()` and includes them.
+- **CRITICAL: always scan by profile NAME**, never by profile ID/UUID. Scanning by name always uses the latest profile version; scanning by ID pins to a versioned snapshot.
 - Topics can't be deleted while referenced by any profile revision
-- **Platform ceilings**: Block-intent topics in high-sensitivity domains (explosives, weapons) trigger built-in AIRS safety that overrides custom definitions (0% TNR). Allow-intent topics use broad semantic matching — exclusion clauses increase FP; shorter descriptions outperform longer ones. Typical allow-intent ceiling: 40–70% coverage.
+- **Platform ceilings**: Block-intent topics in high-sensitivity domains (explosives, weapons) trigger built-in AIRS safety that overrides custom definitions (0% TNR). Allow-intent topics use broad semantic matching — exclusion clauses increase FP; shorter descriptions outperform longer ones. Typical block-intent ceiling: 40–50% coverage due to vocabulary overlap between allow and block domains.
 
 ### Runtime Scanning (`src/airs/runtime.ts`)
 - `SdkRuntimeService` wraps SDK `Scanner` for sync and async scanning

--- a/src/airs/management.ts
+++ b/src/airs/management.ts
@@ -52,6 +52,10 @@ export class SdkManagementService implements ManagementService {
    * Sets one or more custom topics on a profile's topic-guardrails config.
    * Replaces any existing topics — previous runs' stale topics are cleared.
    * Groups topics by action; skips empty action groups (AIRS rejects them).
+   *
+   * CRITICAL: Each topic entry MUST include the current `revision` number.
+   * AIRS pins topic content to the revision specified in the profile — omitting
+   * it defaults to revision 0 (original content), not the latest.
    */
   async assignTopicsToProfile(
     profileName: string,
@@ -64,6 +68,11 @@ export class SdkManagementService implements ManagementService {
     if (!profile?.profile_id) {
       throw new Error(`Profile "${profileName}" not found`);
     }
+
+    // Fetch current topic revisions — AIRS requires the revision field to
+    // reference the correct topic content snapshot.
+    const allTopics = await this.listTopics();
+    const revisionMap = new Map(allTopics.map((t) => [t.topic_id, t.revision ?? 0]));
 
     // Deep clone the policy to mutate
     const policy = JSON.parse(JSON.stringify(profile.policy ?? {}));
@@ -91,17 +100,24 @@ export class SdkManagementService implements ManagementService {
     // 'allow' = allow all unless explicitly blocked (only block topics needed).
     topicGuardrails.action = guardrailAction ?? 'block';
 
-    // Group topics by action, build topic-list entries (skip empty groups).
-    const byAction = new Map<string, Array<{ topic_id: string; topic_name: string }>>();
+    // Group topics by action, build topic-list entries with revision (skip empty groups).
+    const byAction = new Map<
+      string,
+      Array<{ topic_id: string; topic_name: string; revision: number }>
+    >();
     for (const t of topics) {
       const group = byAction.get(t.action) ?? [];
-      group.push({ topic_id: t.topicId, topic_name: t.topicName });
+      group.push({
+        topic_id: t.topicId,
+        topic_name: t.topicName,
+        revision: revisionMap.get(t.topicId) ?? 0,
+      });
       byAction.set(t.action, group);
     }
 
     const topicList: Array<{
       action: string;
-      topic: Array<{ topic_id: string; topic_name: string }>;
+      topic: Array<{ topic_id: string; topic_name: string; revision: number }>;
     }> = [];
     for (const [action, group] of byAction) {
       topicList.push({ action, topic: group });

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -59,11 +59,6 @@ export function registerGenerateCommand(program: Command): void {
     .option('--create-prompt-set', 'Create custom prompt set from test cases after loop', false)
     .option('--prompt-set-name <name>', 'Override auto-generated prompt set name')
     .option('--save-tests <path>', 'Save best iteration test cases to CSV')
-    .option(
-      '--set-profile-allow',
-      "Set topic-guardrails default to 'allow' (skip companion topic, only block-topic matches blocked)",
-      false,
-    )
     .action(async (opts) => {
       try {
         renderHeader();
@@ -92,7 +87,6 @@ export function registerGenerateCommand(program: Command): void {
               : undefined,
             createPromptSet: opts.createPromptSet ?? false,
             promptSetName: opts.promptSetName,
-            setProfileAllow: opts.setProfileAllow ?? false,
           };
         } else {
           userInput = await collectUserInput();

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -267,14 +267,15 @@ export async function* runLoop(
         topicId = response.topic_id;
       }
 
-      // Determine guardrail-level action.
-      // --set-profile-allow: guardrail default is 'allow', only block-topic matches get blocked.
-      // Without it: guardrail default is 'block', requires companion allow topic.
-      const guardrailAction = input.setProfileAllow ? 'allow' : 'block';
+      // Guardrail-level action is the INVERSE of topic intent:
+      // block-intent → guardrailAction='allow' (default: allow, block topics carve out violations)
+      // allow-intent → guardrailAction='block' (default: block, allow topics whitelist content)
+      const guardrailAction = input.intent === 'block' ? 'allow' : 'block';
 
-      if (input.intent === 'block' && !input.setProfileAllow) {
-        // Two-phase: generate companion allow topic for block-intent profiles.
-        // AIRS requires a non-empty allow list when guardrail action is "block".
+      if (input.intent === 'block') {
+        // Two-phase: generate domain-specific allow companion for block-intent.
+        // AIRS needs both allow + block topics sharing the same vocabulary domain
+        // for the matching engine to distinguish benign from malicious content.
         companionTopic = await deps.llm.generateCompanionTopic(topic.name, topic.description);
         yield { type: 'companion:generated', topic: companionTopic };
 
@@ -303,7 +304,7 @@ export async function* runLoop(
         yield { type: 'companion:created', topicId: companionTopicId, topic: companionTopic };
         runState.companionTopic = companionTopic;
 
-        // Wire both topics to profile
+        // Wire both topics to profile with guardrailAction='allow'
         await deps.management.assignTopicsToProfile(
           input.profileName,
           [
@@ -313,7 +314,7 @@ export async function* runLoop(
           guardrailAction,
         );
       } else {
-        // --set-profile-allow or allow-intent: single topic, no companion needed.
+        // Allow-intent: single topic, guardrailAction='block'
         await deps.management.assignTopicsToProfile(
           input.profileName,
           [{ topicId, topicName: topic.name, action: input.intent }],
@@ -327,6 +328,24 @@ export async function* runLoop(
         examples: topic.examples,
         active: true,
       });
+
+      // Re-assign topics to profile so AIRS references the new topic revision.
+      // AIRS pins topic content to the revision in the profile — without this,
+      // the profile would still reference the pre-update revision.
+      const guardrailAction = input.intent === 'block' ? 'allow' : 'block';
+      const topicEntries: Array<{
+        topicId: string;
+        topicName: string;
+        action: 'allow' | 'block';
+      }> = [{ topicId, topicName: topic.name, action: input.intent }];
+      if (input.intent === 'block' && companionTopicId && companionTopic) {
+        topicEntries.unshift({
+          topicId: companionTopicId,
+          topicName: companionTopic.name,
+          action: 'allow',
+        });
+      }
+      await deps.management.assignTopicsToProfile(input.profileName, topicEntries, guardrailAction);
     }
 
     yield { type: 'apply:complete', topicId };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -28,8 +28,6 @@ export interface UserInput {
   maxAccumulatedTests?: number;
   createPromptSet?: boolean;
   promptSetName?: string;
-  /** Set topic-guardrails default action to 'allow' instead of 'block'. */
-  setProfileAllow?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/llm/prompts/generate-companion.ts
+++ b/src/llm/prompts/generate-companion.ts
@@ -3,30 +3,40 @@ import { ChatPromptTemplate } from '@langchain/core/prompts';
 export const generateCompanionPrompt = ChatPromptTemplate.fromMessages([
   [
     'system',
-    `You are an expert at configuring Prisma AIRS custom topic guardrails. Your task is to create a broad ALLOW companion topic that whitelists benign, everyday content.
+    `You are an expert at configuring Prisma AIRS custom topic guardrails. Your task is to create a DOMAIN-SPECIFIC allow topic that covers the BENIGN, LEGITIMATE side of the same vocabulary domain as the block topic.
 
-This companion topic is required because AIRS profiles with default action "block" need a non-empty allow topic list. Without one, all prompts are blocked regardless of the block topic definition.
+CRITICAL ARCHITECTURE REQUIREMENT:
+AIRS topic-guardrails need BOTH allow and block topics that SHARE THE SAME VOCABULARY DOMAIN but differ in intent. The allow topic establishes the benign boundary; the block topic carves out malicious content. Without a domain-overlapping allow topic, AIRS cannot distinguish benign from malicious prompts.
 
-The companion should:
-- Be broadly permissive — cover general, benign, everyday content
-- NOT overlap with the block topic — avoid whitelisting anything the block topic should catch
-- Use simple, short language — AIRS semantic matching works best with concise descriptions
+EXAMPLE — Home improvement chatbot blocking violence:
+- Allow: "Household Tools" — household tools (automotive, cleaning, electrical, hand tools, etc.)
+- Block: "Usage of Household Tools for Violence" — using household items for violent actions
+Both share vocabulary (hammers, paint, rope, chemicals) but differ in intent.
+
+EXAMPLE — Blocking tax evasion:
+- Allow: "Legal Tax Planning" — tax education, compliance, retirement accounts (IRA, 401k), filing, deduction eligibility, legitimate tax optimization
+- Block: "Tax Evasion" — hiding income, fraudulent deductions, offshore evasion schemes
+Both share vocabulary (taxes, deductions, income, accounts) but differ in intent.
+
+The allow topic MUST:
+- Share vocabulary/domain with the block topic (this is what gives AIRS the semantic signal)
+- Describe the BENIGN, LEGITIMATE intent within that domain
+- Cover education, compliance, legal use cases for the same subject matter
+- Be specific enough for AIRS semantic matching (NOT generic "everyday content")
 
 Constraints:
 - Name: max 100 characters, prefix with "Allow: "
-- Description: max 250 characters, broadly define what benign content looks like
-- Examples: 2-3 examples of clearly benign prompts, each max 250 characters
-- Combined total (name + description + all examples) must not exceed 1000 characters
-
-CRITICAL: Keep the description UNDER 80 characters. Shorter = better on AIRS.`,
+- Description: max 250 characters — USE THE FULL BUDGET for precision
+- Examples: 2 examples of clearly benign prompts that use the SAME DOMAIN VOCABULARY as the block topic
+- Combined total (name + description + all examples) must not exceed 1000 characters`,
   ],
   [
     'human',
-    `Create a broad allow companion topic for a profile that blocks the following:
+    `Create a domain-specific allow companion topic for:
 
 Block Topic: {blockTopicName}
 Block Description: {blockTopicDescription}
 
-The allow topic should permit general content that is clearly unrelated to "{blockTopicName}". Keep it broad and simple.`,
+The allow topic must share vocabulary with the block topic but cover the BENIGN, LEGITIMATE side of that domain. Think: education, compliance, legal use, professional guidance within the same subject area.`,
   ],
 ]);

--- a/tests/unit/airs/management.spec.ts
+++ b/tests/unit/airs/management.spec.ts
@@ -4,6 +4,7 @@ import { SdkManagementService } from '../../../src/airs/management.js';
 interface PolicyTopicEntry {
   topic_id: string;
   topic_name: string;
+  revision?: number;
 }
 interface PolicyActionEntry {
   action: string;
@@ -58,6 +59,9 @@ describe('SdkManagementService', () => {
       clientSecret: 'test-secret',
       tsgId: 'tsg-123',
     });
+    // Default topics list for revision lookup in assignTopicsToProfile.
+    // Tests that need specific revisions can override this mock.
+    mockList.mockResolvedValue({ custom_topics: [] });
   });
 
   describe('createTopic', () => {
@@ -177,7 +181,9 @@ describe('SdkManagementService', () => {
       // Only a single topic-list entry for the action (no empty opposite entry)
       expect(tg['topic-list']).toHaveLength(1);
       const blockEntry = tg['topic-list'].find((tl) => tl.action === 'block');
-      expect(blockEntry?.topic).toEqual([{ topic_id: 'topic-1', topic_name: 'Weapons' }]);
+      expect(blockEntry?.topic).toEqual([
+        { topic_id: 'topic-1', topic_name: 'Weapons', revision: 0 },
+      ]);
     });
 
     it('handles profile with no policy (undefined)', async () => {
@@ -259,7 +265,9 @@ describe('SdkManagementService', () => {
       const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
       const blockEntry = tg['topic-list'].find((tl) => tl.action === 'block');
       // Only the current topic — stale ones removed
-      expect(blockEntry?.topic).toEqual([{ topic_id: 'topic-new', topic_name: 'Current Run' }]);
+      expect(blockEntry?.topic).toEqual([
+        { topic_id: 'topic-new', topic_name: 'Current Run', revision: 0 },
+      ]);
     });
 
     it('always updates even when same topic already linked', async () => {
@@ -371,7 +379,7 @@ describe('SdkManagementService', () => {
       expect(tg['topic-list']).toHaveLength(1);
       expect(tg['topic-list'][0].action).toBe('allow');
       expect(tg['topic-list'][0].topic).toEqual([
-        { topic_id: 'topic-1', topic_name: 'Safe Topic' },
+        { topic_id: 'topic-1', topic_name: 'Safe Topic', revision: 0 },
       ]);
     });
 
@@ -452,7 +460,9 @@ describe('SdkManagementService', () => {
       const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
       expect(tg['topic-list']).toHaveLength(1);
       expect(tg['topic-list'][0].action).toBe('block');
-      expect(tg['topic-list'][0].topic).toEqual([{ topic_id: 'topic-1', topic_name: 'Weapons' }]);
+      expect(tg['topic-list'][0].topic).toEqual([
+        { topic_id: 'topic-1', topic_name: 'Weapons', revision: 0 },
+      ]);
     });
 
     it('wires both allow and block topics as separate entries', async () => {
@@ -473,8 +483,12 @@ describe('SdkManagementService', () => {
 
       const allowEntry = tg['topic-list'].find((tl) => tl.action === 'allow');
       const blockEntry = tg['topic-list'].find((tl) => tl.action === 'block');
-      expect(allowEntry?.topic).toEqual([{ topic_id: 'allow-1', topic_name: 'General Content' }]);
-      expect(blockEntry?.topic).toEqual([{ topic_id: 'block-1', topic_name: 'Weapons' }]);
+      expect(allowEntry?.topic).toEqual([
+        { topic_id: 'allow-1', topic_name: 'General Content', revision: 0 },
+      ]);
+      expect(blockEntry?.topic).toEqual([
+        { topic_id: 'block-1', topic_name: 'Weapons', revision: 0 },
+      ]);
     });
 
     it('groups multiple topics under the same action', async () => {
@@ -538,7 +552,9 @@ describe('SdkManagementService', () => {
       const tg = getTopicGuardrails(mockProfileUpdate.mock.calls[0][1]);
       expect(tg['topic-list']).toHaveLength(2);
       const blockEntry = tg['topic-list'].find((tl) => tl.action === 'block');
-      expect(blockEntry?.topic).toEqual([{ topic_id: 'block-1', topic_name: 'Weapons' }]);
+      expect(blockEntry?.topic).toEqual([
+        { topic_id: 'block-1', topic_name: 'Weapons', revision: 0 },
+      ]);
     });
 
     it('defaults guardrail-level action to block', async () => {

--- a/tests/unit/core/loop.spec.ts
+++ b/tests/unit/core/loop.spec.ts
@@ -397,7 +397,7 @@ describe('runLoop', () => {
     expect(companionEvents).toHaveLength(0);
   });
 
-  it('calls assignTopicsToProfile with both topics for block intent (default)', async () => {
+  it('block-intent sets guardrailAction=allow and wires both topics', async () => {
     const management = createMockManagementService();
     const assignTopicsSpy = vi.spyOn(management, 'assignTopicsToProfile');
     const deps = createDeps({ management });
@@ -412,34 +412,29 @@ describe('runLoop', () => {
         expect.objectContaining({ action: 'allow', topicName: 'Allow: General Content' }),
         expect.objectContaining({ action: 'block', topicName: 'Weapons Discussion' }),
       ],
-      'block',
+      'allow',
     );
   });
 
-  it('--set-profile-allow skips companion and sets guardrailAction to allow', async () => {
+  it('allow-intent sets guardrailAction=block with single topic', async () => {
     const management = createMockManagementService();
     const assignTopicsSpy = vi.spyOn(management, 'assignTopicsToProfile');
-    const deps = createDeps({ management });
-    const events: LoopEvent[] = [];
+    const deps = createDeps({
+      management,
+      scanner: createMockAllowScanService([/cats/i]),
+    });
 
-    for await (const event of runLoop(
-      { ...defaultInput, setProfileAllow: true, maxIterations: 1 },
+    for await (const _event of runLoop(
+      { ...defaultInput, intent: 'allow', maxIterations: 1 },
       deps,
     )) {
-      events.push(event);
+      // consume
     }
 
-    // No companion events
-    const companionEvents = events.filter(
-      (e) => e.type === 'companion:generated' || e.type === 'companion:created',
-    );
-    expect(companionEvents).toHaveLength(0);
-
-    // Single block topic with guardrailAction 'allow'
     expect(assignTopicsSpy).toHaveBeenCalledWith(
       'test-profile',
-      [expect.objectContaining({ action: 'block', topicName: 'Weapons Discussion' })],
-      'allow',
+      [expect.objectContaining({ action: 'allow' })],
+      'block',
     );
   });
 


### PR DESCRIPTION
## Summary

- **Root cause**: `assignTopicsToProfile()` omitted the `revision` field in topic-list entries. AIRS pins topic content to the revision number — omitting defaults to revision 0 (original creation content), causing all subsequent topic updates to be invisible to the scanner
- **Fix**: Fetch current topic revisions via `listTopics()` and include them in profile topic-list entries. Re-assign profile after every `updateTopic()` on iter 2+ so the profile tracks the new revision
- **Companion prompt**: Rewritten to generate domain-specific allow topics sharing vocabulary with block topics (e.g., "Legal Tax Planning" for "Tax Evasion") instead of generic "everyday content"
- **guardrailAction**: Block-intent uses `guardrailAction='allow'` (default allow, block topics carve out violations); allow-intent uses `guardrailAction='block'`
- **Removed**: `--set-profile-allow` flag and `setProfileAllow` from UserInput (no longer needed)

## E2E results (Tax Evasion, 3 iterations)

| Iter | TPR | TNR | Coverage |
|------|-----|-----|----------|
| Before fix | 100% | **0%** | **0%** |
| 1 | 100% | 40.0% | 40.0% |
| 2 | 100% | 40.5% | 40.5% |
| 3 | 93.4% | 46.3% | **46.3%** |

## Test plan

- [x] 516 unit tests pass
- [x] Lint + typecheck clean
- [x] E2E: probe succeeds on first attempt (no propagation delay)
- [x] E2E: block-intent topics achieve non-zero TNR across iterations
- [x] E2E: unrelated prompts (cookies, chess) correctly allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)