### PR TITLE
feat: add custom topics CRUD to runtime CLI (#160)

### DIFF
--- a/src/airs/management.ts
+++ b/src/airs/management.ts
@@ -36,6 +36,11 @@ export class SdkManagementService implements ManagementService {
     await this.client.topics.delete(topicId);
   }
 
+  async forceDeleteTopic(topicId: string, updatedBy?: string): Promise<DeleteResponse> {
+    const response = await this.client.topics.forceDelete(topicId, updatedBy);
+    return { message: (response as unknown as Record<string, string>).message };
+  }
+
   async listTopics(): Promise<SdkCustomTopic[]> {
     const response = await this.client.topics.list();
     return response.custom_topics;

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -691,6 +691,8 @@ export interface ManagementService {
   updateTopic(topicId: string, request: CreateCustomTopicRequest): Promise<SdkCustomTopic>;
   /** Delete a custom topic by ID. */
   deleteTopic(topicId: string): Promise<void>;
+  /** Force-delete a custom topic (removes from all referencing profiles). */
+  forceDeleteTopic(topicId: string, updatedBy?: string): Promise<DeleteResponse>;
   /** List all custom topics. */
   listTopics(): Promise<SdkCustomTopic[]>;
   /** Assign a topic to a security profile's topic-guardrails. */

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -13,6 +13,8 @@ import {
   renderProfileDetail,
   renderProfileList,
   renderRuntimeConfigHeader,
+  renderTopicDetail,
+  renderTopicList,
 } from '../renderer.js';
 
 function renderScanResult(result: RuntimeScanResult): void {
@@ -292,6 +294,93 @@ export function registerRuntimeCommand(program: Command): void {
         } else {
           const result = await service.deleteProfile(profileId);
           console.log(`  ${result.message}\n`);
+        }
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // runtime topics — custom topic CRUD subcommands
+  // -----------------------------------------------------------------------
+  const topics = runtime.command('topics').description('Manage AIRS custom topics');
+
+  topics
+    .command('list')
+    .description('List custom topics')
+    .option('--limit <n>', 'Max results', '100')
+    .option('--offset <n>', 'Starting offset', '0')
+    .action(async (opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const allTopics = await service.listTopics();
+        // Client-side pagination since SDK returns all
+        const offset = Number.parseInt(opts.offset, 10);
+        const limit = Number.parseInt(opts.limit, 10);
+        const page = allTopics.slice(offset, offset + limit);
+        renderTopicList(page);
+        if (offset + limit < allTopics.length) {
+          console.log(chalk.dim(`  Showing ${page.length} of ${allTopics.length} topics\n`));
+        }
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  topics
+    .command('create')
+    .description('Create a new custom topic')
+    .requiredOption('--config <path>', 'JSON file with topic configuration')
+    .action(async (opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const topic = await service.createTopic(config);
+        console.log(`  Topic created: ${topic.topic_id}\n`);
+        renderTopicDetail(topic);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  topics
+    .command('update <topicId>')
+    .description('Update a custom topic')
+    .requiredOption('--config <path>', 'JSON file with topic updates')
+    .action(async (topicId: string, opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const topic = await service.updateTopic(topicId, config);
+        console.log(`  Topic updated: ${topic.topic_id}\n`);
+        renderTopicDetail(topic);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  topics
+    .command('delete <topicId>')
+    .description('Delete a custom topic')
+    .option('--force', 'Force delete (removes from all referencing profiles)')
+    .option('--updated-by <email>', 'Email of user performing force deletion')
+    .action(async (topicId: string, opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        if (opts.force) {
+          const result = await service.forceDeleteTopic(topicId, opts.updatedBy);
+          console.log(`  ${result.message}\n`);
+        } else {
+          await service.deleteTopic(topicId);
+          console.log(`  Topic ${topicId} deleted.\n`);
         }
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -772,6 +772,57 @@ export function renderProfileDetail(profile: {
   console.log();
 }
 
+/** Render custom topic list. */
+export function renderTopicList(
+  topics: Array<{
+    topic_id?: string;
+    topic_name: string;
+    description?: string;
+    revision?: number;
+  }>,
+): void {
+  if (topics.length === 0) {
+    console.log(chalk.dim('  No topics found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Custom Topics:\n'));
+  for (const t of topics) {
+    console.log(`  ${chalk.dim(t.topic_id)}`);
+    const rev = t.revision != null ? chalk.dim(` rev:${t.revision}`) : '';
+    const desc = t.description ? chalk.dim(` — ${t.description.slice(0, 80)}`) : '';
+    console.log(`    ${t.topic_name}${rev}${desc}`);
+  }
+  console.log();
+}
+
+/** Render custom topic detail. */
+export function renderTopicDetail(topic: {
+  topic_id?: string;
+  topic_name: string;
+  description?: string;
+  examples?: string[];
+  revision?: number;
+  created_by?: string;
+  updated_by?: string;
+  last_modified_ts?: string;
+}): void {
+  console.log(chalk.bold('\n  Topic Detail:\n'));
+  console.log(`    ID:          ${chalk.dim(topic.topic_id)}`);
+  console.log(`    Name:        ${topic.topic_name}`);
+  if (topic.revision != null) console.log(`    Revision:    ${topic.revision}`);
+  if (topic.description) console.log(`    Description: ${topic.description}`);
+  if (topic.examples?.length) {
+    console.log('    Examples:');
+    for (const ex of topic.examples) {
+      console.log(`      ${chalk.dim('•')} ${ex}`);
+    }
+  }
+  if (topic.created_by) console.log(`    Created:     ${chalk.dim(topic.created_by)}`);
+  if (topic.updated_by) console.log(`    Updated:     ${chalk.dim(topic.updated_by)}`);
+  if (topic.last_modified_ts) console.log(`    Modified:    ${chalk.dim(topic.last_modified_ts)}`);
+  console.log();
+}
+
 // ---------------------------------------------------------------------------
 // Model Security rendering
 // ---------------------------------------------------------------------------

--- a/tests/unit/airs/management.spec.ts
+++ b/tests/unit/airs/management.spec.ts
@@ -132,6 +132,24 @@ describe('SdkManagementService', () => {
     });
   });
 
+  describe('forceDeleteTopic', () => {
+    it('force-deletes a topic via SDK', async () => {
+      mockForceDelete.mockResolvedValue({ message: 'force deleted' });
+
+      const result = await service.forceDeleteTopic('topic-abc', 'admin@example.com');
+      expect(result.message).toBe('force deleted');
+      expect(mockForceDelete).toHaveBeenCalledWith('topic-abc', 'admin@example.com');
+    });
+
+    it('works without updatedBy param', async () => {
+      mockForceDelete.mockResolvedValue({ message: 'force deleted' });
+
+      const result = await service.forceDeleteTopic('topic-abc');
+      expect(result.message).toBe('force deleted');
+      expect(mockForceDelete).toHaveBeenCalledWith('topic-abc', undefined);
+    });
+  });
+
   describe('listTopics', () => {
     it('lists topics and unwraps custom_topics array', async () => {
       mockList.mockResolvedValue({


### PR DESCRIPTION
## Summary
- Adds `daystrom runtime topics` subcommand group: list, create, update, delete (with `--force` flag)
- Adds `forceDeleteTopic` to `ManagementService` interface and `SdkManagementService`
- Adds `renderTopicList`, `renderTopicDetail` renderer functions

## Testing
- 2 new unit tests for `forceDeleteTopic`
- All 525 tests passing
- Lint, format, typecheck all clean

## CLI Usage
```bash
daystrom runtime topics list [--limit <n>] [--offset <n>]
daystrom runtime topics create --config <path.json>
daystrom runtime topics update <topicId> --config <path.json>
daystrom runtime topics delete <topicId> [--force [--updated-by <email>]]
```

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)