### PR TITLE
feat: add api-keys, customer-apps, deployment/dlp profiles, scan-logs to runtime CLI

### DIFF
--- a/src/airs/management.ts
+++ b/src/airs/management.ts
@@ -6,9 +6,17 @@ import {
 } from '@cdot65/prisma-airs-sdk';
 import type { ProfileTopic } from '../audit/types.js';
 import type {
+  ApiKeyInfo,
+  ApiKeyListResult,
+  CustomerAppInfo,
+  CustomerAppListResult,
   DeleteResponse,
+  DeploymentProfileInfo,
+  DlpProfileInfo,
   ManagementService,
   PaginationOptions,
+  ScanLogQueryOptions,
+  ScanLogQueryResult,
   SecurityProfileInfo,
   SecurityProfileListResult,
 } from './types.js';
@@ -251,5 +259,127 @@ export class SdkManagementService implements ManagementService {
   async forceDeleteProfile(profileId: string, updatedBy: string): Promise<DeleteResponse> {
     const response = await this.client.profiles.forceDelete(profileId, updatedBy);
     return { message: (response as unknown as Record<string, string>).message };
+  }
+
+  // -------------------------------------------------------------------------
+  // API Keys
+  // -------------------------------------------------------------------------
+
+  private normalizeApiKey(k: Record<string, unknown>): ApiKeyInfo {
+    return {
+      id: (k.id ?? k.api_key_id ?? '') as string,
+      name: (k.name ?? k.api_key_name ?? '') as string,
+      createdAt: k.created_at as string | undefined,
+      expiresAt: k.expires_at as string | undefined,
+    };
+  }
+
+  async listApiKeys(opts?: PaginationOptions): Promise<ApiKeyListResult> {
+    const response = await this.client.apiKeys.list(opts);
+    const raw = response as unknown as Record<string, unknown>;
+    const keys = (raw.api_keys ?? []) as Record<string, unknown>[];
+    return {
+      apiKeys: keys.map((k) => this.normalizeApiKey(k)),
+      nextOffset: raw.next_offset as number | undefined,
+    };
+  }
+
+  async createApiKey(request: Record<string, unknown>): Promise<ApiKeyInfo> {
+    const response = await this.client.apiKeys.create(request as never);
+    return this.normalizeApiKey(response as unknown as Record<string, unknown>);
+  }
+
+  async regenerateApiKey(apiKeyId: string, request: Record<string, unknown>): Promise<ApiKeyInfo> {
+    const response = await this.client.apiKeys.regenerate(apiKeyId, request as never);
+    return this.normalizeApiKey(response as unknown as Record<string, unknown>);
+  }
+
+  async deleteApiKey(apiKeyName: string, updatedBy: string): Promise<DeleteResponse> {
+    const response = await this.client.apiKeys.delete(apiKeyName, updatedBy);
+    return { message: (response as unknown as Record<string, string>).message };
+  }
+
+  // -------------------------------------------------------------------------
+  // Customer Apps
+  // -------------------------------------------------------------------------
+
+  private normalizeCustomerApp(a: Record<string, unknown>): CustomerAppInfo {
+    return {
+      id: (a.customer_app_id ?? a.id) as string | undefined,
+      name: (a.app_name ?? a.name ?? '') as string,
+      description: a.description as string | undefined,
+      raw: a,
+    };
+  }
+
+  async listCustomerApps(opts?: PaginationOptions): Promise<CustomerAppListResult> {
+    const response = await this.client.customerApps.list(opts);
+    const raw = response as unknown as Record<string, unknown>;
+    const apps = (raw.customer_apps ?? []) as Record<string, unknown>[];
+    return {
+      apps: apps.map((a) => this.normalizeCustomerApp(a)),
+      nextOffset: raw.next_offset as number | undefined,
+    };
+  }
+
+  async getCustomerApp(appName: string): Promise<CustomerAppInfo> {
+    const response = await this.client.customerApps.get(appName);
+    return this.normalizeCustomerApp(response as unknown as Record<string, unknown>);
+  }
+
+  async updateCustomerApp(
+    appId: string,
+    request: Record<string, unknown>,
+  ): Promise<CustomerAppInfo> {
+    const response = await this.client.customerApps.update(appId, request as never);
+    return this.normalizeCustomerApp(response as unknown as Record<string, unknown>);
+  }
+
+  async deleteCustomerApp(appName: string, updatedBy: string): Promise<CustomerAppInfo> {
+    const response = await this.client.customerApps.delete(appName, updatedBy);
+    return this.normalizeCustomerApp(response as unknown as Record<string, unknown>);
+  }
+
+  // -------------------------------------------------------------------------
+  // Deployment Profiles (read-only)
+  // -------------------------------------------------------------------------
+
+  async listDeploymentProfiles(opts?: { unactivated?: boolean }): Promise<DeploymentProfileInfo[]> {
+    const response = await this.client.deploymentProfiles.list(opts);
+    const raw = response as unknown as Record<string, unknown>;
+    const profiles = (raw.deployment_profiles ?? []) as Record<string, unknown>[];
+    return profiles.map((p) => ({ raw: p }));
+  }
+
+  // -------------------------------------------------------------------------
+  // DLP Profiles (read-only)
+  // -------------------------------------------------------------------------
+
+  async listDlpProfiles(): Promise<DlpProfileInfo[]> {
+    const response = await this.client.dlpProfiles.list();
+    const raw = response as unknown as Record<string, unknown>;
+    const profiles = (raw.dlp_profiles ?? []) as Record<string, unknown>[];
+    return profiles.map((p) => ({ raw: p }));
+  }
+
+  // -------------------------------------------------------------------------
+  // Scan Logs
+  // -------------------------------------------------------------------------
+
+  async queryScanLogs(opts: ScanLogQueryOptions): Promise<ScanLogQueryResult> {
+    const response = await this.client.scanLogs.query({
+      time_interval: opts.timeInterval,
+      time_unit: opts.timeUnit,
+      pageNumber: opts.pageNumber,
+      pageSize: opts.pageSize,
+      filter: opts.filter,
+      page_token: opts.pageToken,
+    });
+    const raw = response as unknown as Record<string, unknown>;
+    return {
+      results: (raw.results ?? []) as Record<string, unknown>[],
+      pageToken: raw.page_token as string | undefined,
+      raw,
+    };
   }
 }

--- a/src/airs/types.ts
+++ b/src/airs/types.ts
@@ -680,6 +680,81 @@ export interface PaginationOptions {
 }
 
 // ---------------------------------------------------------------------------
+// API key types
+// ---------------------------------------------------------------------------
+
+/** Normalized API key. */
+export interface ApiKeyInfo {
+  id: string;
+  name: string;
+  createdAt?: string;
+  expiresAt?: string;
+}
+
+/** Paginated API key list. */
+export interface ApiKeyListResult {
+  apiKeys: ApiKeyInfo[];
+  nextOffset?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Customer app types
+// ---------------------------------------------------------------------------
+
+/** Normalized customer app. */
+export interface CustomerAppInfo {
+  id?: string;
+  name: string;
+  description?: string;
+  raw: Record<string, unknown>;
+}
+
+/** Paginated customer app list. */
+export interface CustomerAppListResult {
+  apps: CustomerAppInfo[];
+  nextOffset?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Deployment profile types
+// ---------------------------------------------------------------------------
+
+/** Normalized deployment profile. */
+export interface DeploymentProfileInfo {
+  raw: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// DLP profile types
+// ---------------------------------------------------------------------------
+
+/** Normalized DLP profile. */
+export interface DlpProfileInfo {
+  raw: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Scan log types
+// ---------------------------------------------------------------------------
+
+/** Options for querying scan logs. */
+export interface ScanLogQueryOptions {
+  timeInterval: number;
+  timeUnit: string;
+  pageNumber: number;
+  pageSize: number;
+  filter: string;
+  pageToken?: string;
+}
+
+/** Scan log query result. */
+export interface ScanLogQueryResult {
+  results: Record<string, unknown>[];
+  pageToken?: string;
+  raw: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
 // Management service interface
 // ---------------------------------------------------------------------------
 
@@ -721,4 +796,25 @@ export interface ManagementService {
   deleteProfile(profileId: string): Promise<DeleteResponse>;
   /** Force-delete a security profile (removes from referencing policies). */
   forceDeleteProfile(profileId: string, updatedBy: string): Promise<DeleteResponse>;
+
+  // API keys
+  listApiKeys(opts?: PaginationOptions): Promise<ApiKeyListResult>;
+  createApiKey(request: Record<string, unknown>): Promise<ApiKeyInfo>;
+  regenerateApiKey(apiKeyId: string, request: Record<string, unknown>): Promise<ApiKeyInfo>;
+  deleteApiKey(apiKeyName: string, updatedBy: string): Promise<DeleteResponse>;
+
+  // Customer apps
+  listCustomerApps(opts?: PaginationOptions): Promise<CustomerAppListResult>;
+  getCustomerApp(appName: string): Promise<CustomerAppInfo>;
+  updateCustomerApp(appId: string, request: Record<string, unknown>): Promise<CustomerAppInfo>;
+  deleteCustomerApp(appName: string, updatedBy: string): Promise<CustomerAppInfo>;
+
+  // Deployment profiles
+  listDeploymentProfiles(opts?: { unactivated?: boolean }): Promise<DeploymentProfileInfo[]>;
+
+  // DLP profiles
+  listDlpProfiles(): Promise<DlpProfileInfo[]>;
+
+  // Scan logs
+  queryScanLogs(opts: ScanLogQueryOptions): Promise<ScanLogQueryResult>;
 }

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -9,10 +9,17 @@ import { loadConfig } from '../../config/loader.js';
 import { loadBulkScanState, saveBulkScanState } from '../bulk-scan-state.js';
 import { parseInputFile } from '../parse-input.js';
 import {
+  renderApiKeyDetail,
+  renderApiKeyList,
+  renderCustomerAppDetail,
+  renderCustomerAppList,
+  renderDeploymentProfileList,
+  renderDlpProfileList,
   renderError,
   renderProfileDetail,
   renderProfileList,
   renderRuntimeConfigHeader,
+  renderScanLogList,
   renderTopicDetail,
   renderTopicList,
 } from '../renderer.js';
@@ -382,6 +389,229 @@ export function registerRuntimeCommand(program: Command): void {
           await service.deleteTopic(topicId);
           console.log(`  Topic ${topicId} deleted.\n`);
         }
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // runtime api-keys — API key management subcommands
+  // -----------------------------------------------------------------------
+  const apiKeys = runtime.command('api-keys').description('Manage AIRS API keys');
+
+  apiKeys
+    .command('list')
+    .description('List API keys')
+    .option('--limit <n>', 'Max results', '100')
+    .action(async (opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const result = await service.listApiKeys({
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderApiKeyList(result.apiKeys);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  apiKeys
+    .command('create')
+    .description('Create a new API key')
+    .requiredOption('--config <path>', 'JSON file with API key configuration')
+    .action(async (opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const key = await service.createApiKey(config);
+        console.log(`  API key created: ${key.id}\n`);
+        renderApiKeyDetail(key);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  apiKeys
+    .command('regenerate <apiKeyId>')
+    .description('Regenerate an API key')
+    .requiredOption('--config <path>', 'JSON file with regeneration config')
+    .action(async (apiKeyId: string, opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const key = await service.regenerateApiKey(apiKeyId, config);
+        console.log(`  API key regenerated: ${key.id}\n`);
+        renderApiKeyDetail(key);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  apiKeys
+    .command('delete <apiKeyName>')
+    .description('Delete an API key')
+    .requiredOption('--updated-by <email>', 'Email of user performing deletion')
+    .action(async (apiKeyName: string, opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const result = await service.deleteApiKey(apiKeyName, opts.updatedBy);
+        console.log(`  ${result.message}\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // runtime customer-apps — customer app management subcommands
+  // -----------------------------------------------------------------------
+  const customerApps = runtime.command('customer-apps').description('Manage AIRS customer apps');
+
+  customerApps
+    .command('list')
+    .description('List customer apps')
+    .option('--limit <n>', 'Max results', '100')
+    .action(async (opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const result = await service.listCustomerApps({
+          limit: Number.parseInt(opts.limit, 10),
+        });
+        renderCustomerAppList(result.apps);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  customerApps
+    .command('get <appName>')
+    .description('Get customer app details')
+    .action(async (appName: string) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const app = await service.getCustomerApp(appName);
+        renderCustomerAppDetail(app);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  customerApps
+    .command('update <appId>')
+    .description('Update a customer app')
+    .requiredOption('--config <path>', 'JSON file with app updates')
+    .action(async (appId: string, opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const config = JSON.parse(fs.readFileSync(opts.config, 'utf-8'));
+        const app = await service.updateCustomerApp(appId, config);
+        console.log(`  Customer app updated: ${app.name}\n`);
+        renderCustomerAppDetail(app);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  customerApps
+    .command('delete <appName>')
+    .description('Delete a customer app')
+    .requiredOption('--updated-by <email>', 'Email of user performing deletion')
+    .action(async (appName: string, opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const app = await service.deleteCustomerApp(appName, opts.updatedBy);
+        console.log(`  Customer app "${app.name}" deleted.\n`);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // runtime deployment-profiles — read-only listing
+  // -----------------------------------------------------------------------
+  const deploymentProfiles = runtime
+    .command('deployment-profiles')
+    .description('List AIRS deployment profiles');
+
+  deploymentProfiles
+    .command('list')
+    .description('List deployment profiles')
+    .option('--unactivated', 'Include unactivated profiles')
+    .action(async (opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const profiles = await service.listDeploymentProfiles({
+          unactivated: opts.unactivated,
+        });
+        renderDeploymentProfileList(profiles);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // runtime dlp-profiles — read-only listing
+  // -----------------------------------------------------------------------
+  const dlpProfiles = runtime.command('dlp-profiles').description('List AIRS DLP profiles');
+
+  dlpProfiles
+    .command('list')
+    .description('List DLP profiles')
+    .action(async () => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const profiles = await service.listDlpProfiles();
+        renderDlpProfileList(profiles);
+      } catch (err) {
+        renderError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    });
+
+  // -----------------------------------------------------------------------
+  // runtime scan-logs — scan log query
+  // -----------------------------------------------------------------------
+  const scanLogs = runtime.command('scan-logs').description('Query AIRS scan logs');
+
+  scanLogs
+    .command('query')
+    .description('Query scan logs')
+    .requiredOption('--interval <n>', 'Time interval')
+    .requiredOption('--unit <unit>', 'Time unit (hour, day, week, month)')
+    .option('--filter <filter>', 'Filter: all, benign, threat', 'all')
+    .option('--page <n>', 'Page number', '1')
+    .option('--page-size <n>', 'Page size', '50')
+    .action(async (opts) => {
+      try {
+        renderRuntimeConfigHeader();
+        const service = await createMgmtService();
+        const result = await service.queryScanLogs({
+          timeInterval: Number.parseInt(opts.interval, 10),
+          timeUnit: opts.unit,
+          pageNumber: Number.parseInt(opts.page, 10),
+          pageSize: Number.parseInt(opts.pageSize, 10),
+          filter: opts.filter,
+        });
+        renderScanLogList(result.results, result.pageToken);
       } catch (err) {
         renderError(err instanceof Error ? err.message : String(err));
         process.exit(1);

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -823,6 +823,126 @@ export function renderTopicDetail(topic: {
   console.log();
 }
 
+/** Render API key list. */
+export function renderApiKeyList(
+  keys: Array<{ id: string; name: string; createdAt?: string; expiresAt?: string }>,
+): void {
+  if (keys.length === 0) {
+    console.log(chalk.dim('  No API keys found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  API Keys:\n'));
+  for (const k of keys) {
+    console.log(`  ${chalk.dim(k.id)}`);
+    const expires = k.expiresAt ? chalk.dim(` expires: ${k.expiresAt}`) : '';
+    console.log(`    ${k.name}${expires}`);
+  }
+  console.log();
+}
+
+/** Render API key detail. */
+export function renderApiKeyDetail(key: {
+  id: string;
+  name: string;
+  createdAt?: string;
+  expiresAt?: string;
+}): void {
+  console.log(chalk.bold('\n  API Key Detail:\n'));
+  console.log(`    ID:      ${chalk.dim(key.id)}`);
+  console.log(`    Name:    ${key.name}`);
+  if (key.createdAt) console.log(`    Created: ${chalk.dim(key.createdAt)}`);
+  if (key.expiresAt) console.log(`    Expires: ${chalk.dim(key.expiresAt)}`);
+  console.log();
+}
+
+/** Render customer app list. */
+export function renderCustomerAppList(
+  apps: Array<{ id?: string; name: string; description?: string }>,
+): void {
+  if (apps.length === 0) {
+    console.log(chalk.dim('  No customer apps found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Customer Apps:\n'));
+  for (const a of apps) {
+    if (a.id) console.log(`  ${chalk.dim(a.id)}`);
+    const desc = a.description ? chalk.dim(` — ${a.description.slice(0, 80)}`) : '';
+    console.log(`    ${a.name}${desc}`);
+  }
+  console.log();
+}
+
+/** Render customer app detail. */
+export function renderCustomerAppDetail(app: {
+  id?: string;
+  name: string;
+  description?: string;
+  raw: Record<string, unknown>;
+}): void {
+  console.log(chalk.bold('\n  Customer App Detail:\n'));
+  if (app.id) console.log(`    ID:   ${chalk.dim(app.id)}`);
+  console.log(`    Name: ${app.name}`);
+  if (app.description) console.log(`    Desc: ${app.description}`);
+  console.log(`    Data: ${chalk.dim(JSON.stringify(app.raw, null, 2).slice(0, 500))}`);
+  console.log();
+}
+
+/** Render deployment profile list. */
+export function renderDeploymentProfileList(
+  profiles: Array<{ raw: Record<string, unknown> }>,
+): void {
+  if (profiles.length === 0) {
+    console.log(chalk.dim('  No deployment profiles found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  Deployment Profiles:\n'));
+  for (const p of profiles) {
+    const name = (p.raw.profile_name ?? p.raw.name ?? 'unknown') as string;
+    const id = (p.raw.profile_id ?? '') as string;
+    if (id) console.log(`  ${chalk.dim(id)}`);
+    console.log(`    ${name}`);
+  }
+  console.log();
+}
+
+/** Render DLP profile list. */
+export function renderDlpProfileList(profiles: Array<{ raw: Record<string, unknown> }>): void {
+  if (profiles.length === 0) {
+    console.log(chalk.dim('  No DLP profiles found.\n'));
+    return;
+  }
+  console.log(chalk.bold('\n  DLP Profiles:\n'));
+  for (const p of profiles) {
+    const name = (p.raw.profile_name ?? p.raw.name ?? 'unknown') as string;
+    const id = (p.raw.profile_id ?? '') as string;
+    if (id) console.log(`  ${chalk.dim(id)}`);
+    console.log(`    ${name}`);
+  }
+  console.log();
+}
+
+/** Render scan log results. */
+export function renderScanLogList(results: Record<string, unknown>[], pageToken?: string): void {
+  if (results.length === 0) {
+    console.log(chalk.dim('  No scan logs found.\n'));
+    return;
+  }
+  console.log(chalk.bold(`\n  Scan Logs (${results.length} results):\n`));
+  for (const r of results) {
+    const action = r.action as string | undefined;
+    const category = r.category as string | undefined;
+    const ts = r.timestamp as string | undefined;
+    const actionColor = action === 'block' ? chalk.red : chalk.green;
+    console.log(
+      `  ${ts ? chalk.dim(ts) : ''}  ${action ? actionColor(action) : ''}  ${category ?? ''}`,
+    );
+  }
+  if (pageToken) {
+    console.log(chalk.dim(`\n  Page token: ${pageToken}`));
+  }
+  console.log();
+}
+
 // ---------------------------------------------------------------------------
 // Model Security rendering
 // ---------------------------------------------------------------------------

--- a/tests/unit/airs/management.spec.ts
+++ b/tests/unit/airs/management.spec.ts
@@ -35,6 +35,17 @@ const mockProfileUpdate = vi.fn();
 const mockProfileCreate = vi.fn();
 const mockProfileDelete = vi.fn();
 const mockProfileForceDelete = vi.fn();
+const mockApiKeysList = vi.fn();
+const mockApiKeysCreate = vi.fn();
+const mockApiKeysRegenerate = vi.fn();
+const mockApiKeysDelete = vi.fn();
+const mockCustomerAppsList = vi.fn();
+const mockCustomerAppsGet = vi.fn();
+const mockCustomerAppsUpdate = vi.fn();
+const mockCustomerAppsDelete = vi.fn();
+const mockDeploymentProfilesList = vi.fn();
+const mockDlpProfilesList = vi.fn();
+const mockScanLogsQuery = vi.fn();
 
 vi.mock('@cdot65/prisma-airs-sdk', () => ({
   ManagementClient: vi.fn().mockImplementation(() => ({
@@ -51,6 +62,27 @@ vi.mock('@cdot65/prisma-airs-sdk', () => ({
       create: mockProfileCreate,
       delete: mockProfileDelete,
       forceDelete: mockProfileForceDelete,
+    },
+    apiKeys: {
+      list: mockApiKeysList,
+      create: mockApiKeysCreate,
+      regenerate: mockApiKeysRegenerate,
+      delete: mockApiKeysDelete,
+    },
+    customerApps: {
+      list: mockCustomerAppsList,
+      get: mockCustomerAppsGet,
+      update: mockCustomerAppsUpdate,
+      delete: mockCustomerAppsDelete,
+    },
+    deploymentProfiles: {
+      list: mockDeploymentProfilesList,
+    },
+    dlpProfiles: {
+      list: mockDlpProfilesList,
+    },
+    scanLogs: {
+      query: mockScanLogsQuery,
     },
   })),
 }));
@@ -880,6 +912,181 @@ describe('SdkManagementService', () => {
       const result = await service.forceDeleteProfile('p-1', 'admin@example.com');
       expect(result.message).toBe('force deleted');
       expect(mockProfileForceDelete).toHaveBeenCalledWith('p-1', 'admin@example.com');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // API Keys
+  // -------------------------------------------------------------------------
+
+  describe('listApiKeys', () => {
+    it('lists and normalizes API keys', async () => {
+      mockApiKeysList.mockResolvedValue({
+        api_keys: [
+          { id: 'k1', name: 'key-one', created_at: '2026-01-01' },
+          { id: 'k2', name: 'key-two' },
+        ],
+        next_offset: 2,
+      });
+
+      const result = await service.listApiKeys({ limit: 10 });
+      expect(result.apiKeys).toHaveLength(2);
+      expect(result.apiKeys[0].id).toBe('k1');
+      expect(result.apiKeys[0].name).toBe('key-one');
+      expect(result.nextOffset).toBe(2);
+    });
+  });
+
+  describe('createApiKey', () => {
+    it('creates an API key', async () => {
+      mockApiKeysCreate.mockResolvedValue({ id: 'k-new', name: 'new-key' });
+
+      const result = await service.createApiKey({ name: 'new-key' });
+      expect(result.id).toBe('k-new');
+      expect(mockApiKeysCreate).toHaveBeenCalledWith({ name: 'new-key' });
+    });
+  });
+
+  describe('regenerateApiKey', () => {
+    it('regenerates an API key', async () => {
+      mockApiKeysRegenerate.mockResolvedValue({ id: 'k1', name: 'key-one' });
+
+      const result = await service.regenerateApiKey('k1', { rotate: true });
+      expect(result.id).toBe('k1');
+      expect(mockApiKeysRegenerate).toHaveBeenCalledWith('k1', { rotate: true });
+    });
+  });
+
+  describe('deleteApiKey', () => {
+    it('deletes an API key', async () => {
+      mockApiKeysDelete.mockResolvedValue({ message: 'deleted' });
+
+      const result = await service.deleteApiKey('key-one', 'admin@test.com');
+      expect(result.message).toBe('deleted');
+      expect(mockApiKeysDelete).toHaveBeenCalledWith('key-one', 'admin@test.com');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Customer Apps
+  // -------------------------------------------------------------------------
+
+  describe('listCustomerApps', () => {
+    it('lists and normalizes customer apps', async () => {
+      mockCustomerAppsList.mockResolvedValue({
+        customer_apps: [
+          { customer_app_id: 'a1', app_name: 'App One' },
+          { customer_app_id: 'a2', app_name: 'App Two' },
+        ],
+      });
+
+      const result = await service.listCustomerApps();
+      expect(result.apps).toHaveLength(2);
+      expect(result.apps[0].name).toBe('App One');
+    });
+  });
+
+  describe('getCustomerApp', () => {
+    it('gets a customer app by name', async () => {
+      mockCustomerAppsGet.mockResolvedValue({ app_name: 'App One', customer_app_id: 'a1' });
+
+      const result = await service.getCustomerApp('App One');
+      expect(result.name).toBe('App One');
+      expect(mockCustomerAppsGet).toHaveBeenCalledWith('App One');
+    });
+  });
+
+  describe('updateCustomerApp', () => {
+    it('updates a customer app', async () => {
+      mockCustomerAppsUpdate.mockResolvedValue({
+        customer_app_id: 'a1',
+        app_name: 'Updated App',
+      });
+
+      const result = await service.updateCustomerApp('a1', { app_name: 'Updated App' });
+      expect(result.name).toBe('Updated App');
+    });
+  });
+
+  describe('deleteCustomerApp', () => {
+    it('deletes a customer app', async () => {
+      mockCustomerAppsDelete.mockResolvedValue({
+        app_name: 'App One',
+        customer_app_id: 'a1',
+      });
+
+      const result = await service.deleteCustomerApp('App One', 'admin@test.com');
+      expect(result.name).toBe('App One');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Deployment Profiles
+  // -------------------------------------------------------------------------
+
+  describe('listDeploymentProfiles', () => {
+    it('lists deployment profiles', async () => {
+      mockDeploymentProfilesList.mockResolvedValue({
+        deployment_profiles: [{ profile_name: 'default', profile_id: 'dp-1' }],
+      });
+
+      const result = await service.listDeploymentProfiles();
+      expect(result).toHaveLength(1);
+      expect(result[0].raw.profile_name).toBe('default');
+    });
+
+    it('passes unactivated option', async () => {
+      mockDeploymentProfilesList.mockResolvedValue({ deployment_profiles: [] });
+
+      await service.listDeploymentProfiles({ unactivated: true });
+      expect(mockDeploymentProfilesList).toHaveBeenCalledWith({ unactivated: true });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DLP Profiles
+  // -------------------------------------------------------------------------
+
+  describe('listDlpProfiles', () => {
+    it('lists DLP profiles', async () => {
+      mockDlpProfilesList.mockResolvedValue({
+        dlp_profiles: [{ profile_name: 'dlp-default', profile_id: 'dlp-1' }],
+      });
+
+      const result = await service.listDlpProfiles();
+      expect(result).toHaveLength(1);
+      expect(result[0].raw.profile_name).toBe('dlp-default');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scan Logs
+  // -------------------------------------------------------------------------
+
+  describe('queryScanLogs', () => {
+    it('queries scan logs with correct params', async () => {
+      mockScanLogsQuery.mockResolvedValue({
+        results: [{ action: 'block', category: 'weapons' }],
+        page_token: 'next-page',
+      });
+
+      const result = await service.queryScanLogs({
+        timeInterval: 24,
+        timeUnit: 'hour',
+        pageNumber: 1,
+        pageSize: 50,
+        filter: 'threat',
+      });
+      expect(result.results).toHaveLength(1);
+      expect(result.pageToken).toBe('next-page');
+      expect(mockScanLogsQuery).toHaveBeenCalledWith({
+        time_interval: 24,
+        time_unit: 'hour',
+        pageNumber: 1,
+        pageSize: 50,
+        filter: 'threat',
+        page_token: undefined,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `daystrom runtime api-keys` subcommand group: list, create, regenerate, delete
- Adds `daystrom runtime customer-apps` subcommand group: list, get, update, delete
- Adds `daystrom runtime deployment-profiles list` (read-only, with `--unactivated` flag)
- Adds `daystrom runtime dlp-profiles list` (read-only)
- Adds `daystrom runtime scan-logs query` with time range, filter, and pagination options
- Full service layer, types, renderers, and unit tests for all resources

## Testing
- 12 new unit tests covering all service methods
- All 537 tests passing
- Lint, format, typecheck all clean

## CLI Usage
```bash
# API Keys
daystrom runtime api-keys list [--limit <n>]
daystrom runtime api-keys create --config <path.json>
daystrom runtime api-keys regenerate <apiKeyId> --config <path.json>
daystrom runtime api-keys delete <apiKeyName> --updated-by <email>

# Customer Apps
daystrom runtime customer-apps list [--limit <n>]
daystrom runtime customer-apps get <appName>
daystrom runtime customer-apps update <appId> --config <path.json>
daystrom runtime customer-apps delete <appName> --updated-by <email>

# Deployment Profiles
daystrom runtime deployment-profiles list [--unactivated]

# DLP Profiles
daystrom runtime dlp-profiles list

# Scan Logs
daystrom runtime scan-logs query --interval <n> --unit <unit> [--filter all|benign|threat] [--page <n>] [--page-size <n>]
```

Closes #161
Closes #162
Closes #163
Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)