### PR TITLE
chore: link SDK downloadTemplate workaround to upstream issue (#171)

### DIFF
--- a/src/airs/promptsets.ts
+++ b/src/airs/promptsets.ts
@@ -104,9 +104,10 @@ export class SdkPromptSetService implements PromptSetService {
   }
 
   async downloadTemplate(uuid: string): Promise<string> {
-    // Bypass SDK's downloadTemplate — it routes through managementHttpRequest
-    // which unconditionally JSON.parse()s the response, but this endpoint
-    // returns text/csv. Make a raw fetch using the SDK's OAuth client instead.
+    // WORKAROUND: Bypass SDK's downloadTemplate — it routes through managementHttpRequest
+    // which unconditionally JSON.parse()s the response, but this endpoint returns text/csv.
+    // Make a raw fetch using the SDK's OAuth client instead.
+    // Tracked upstream: https://github.com/cdot65/prisma-airs-sdk/issues/77
     const internals = this.client.customAttacks as unknown as {
       baseUrl: string;
       oauthClient: { getToken(): Promise<string> };


### PR DESCRIPTION
## Summary
- Filed upstream issue: https://github.com/cdot65/prisma-airs-sdk/issues/77
- Added `WORKAROUND` label + upstream issue link to code comment in `src/airs/promptsets.ts`

Closes #171

## Test plan
- [x] No code changes — comment only

🤖 Generated with [Claude Code](https://claude.com/claude-code)