### PR TITLE
ci: add coverage threshold enforcement (#172)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test
+      - run: pnpm test:coverage
 
   docs-build:
     runs-on: ubuntu-latest

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/cli/**', 'src/index.ts', 'src/**/types.ts'],
+      thresholds: {
+        lines: 90,
+        functions: 95,
+        branches: 80,
+        statements: 90,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add coverage thresholds to vitest.config.ts: 90% lines/statements, 95% functions, 80% branches
- CI test job now runs `pnpm test:coverage` instead of `pnpm test`
- Coverage will fail CI if it drops below thresholds

Closes #172

## Test plan
- [x] `pnpm test:coverage` passes locally with thresholds
- [x] Thresholds set conservatively below current baseline (~98% lines, ~95% branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)