### PR TITLE
docs: fix inaccurate CLI docs, improve README UX (#177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Node 20+](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org/)
 
-**CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, and profile audits.**
+**Full operational coverage over Palo Alto Prisma AIRS AI security — guardrail refinement, runtime scanning, AI red teaming, model security, and profile audits.**
+
+> **[Read the full documentation](https://cdot65.github.io/daystrom/)** — installation, configuration, architecture, CLI reference, and examples.
 
 ## Install
 
@@ -21,24 +23,18 @@ cp .env.example .env   # add your API keys
 daystrom generate       # interactive guardrail generation
 ```
 
-## Documentation
-
-Full docs — installation, configuration, architecture, CLI reference, examples, and more:
-
-**[cdot65.github.io/daystrom](https://cdot65.github.io/daystrom/)**
-
 ## Commands
 
 | Command | Description |
 |---------|-------------|
 | `generate` | LLM-driven guardrail generation with iterative refinement |
 | `resume` | Resume a paused or failed generation run |
-| `report` | View results for a saved run |
+| `report` | View results for a saved run (terminal, JSON, HTML) |
 | `list` | List all saved runs |
-| `runtime` | Prompt scanning + AIRS config management (profiles, topics, API keys, apps) |
+| `runtime` | Prompt scanning + config management (profiles, topics, API keys, apps, scan logs) |
 | `audit` | Multi-topic profile evaluation with conflict detection |
-| `redteam` | Red team scanning — targets, prompt sets, scans, reports |
-| `model-security` | ML model supply chain security — groups, rules, scans |
+| `redteam` | Adversarial scanning — targets, prompt sets, scans, reports |
+| `model-security` | ML model supply chain security — groups, rules, scans, labels |
 
 ## License
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -44,7 +44,7 @@ graph LR
 | Domain | CLI Commands | Service Layer |
 |--------|-------------|---------------|
 | **Guardrail Generation** | `generate`, `resume`, `report`, `list` | Core loop + LLM + Scanner + Management |
-| **Runtime Security** | `runtime scan`, `runtime bulk-scan` | `SdkRuntimeService` (sync + async scan) |
+| **Runtime Security** | `runtime scan`, `runtime bulk-scan`, `runtime profiles`, `runtime topics`, `runtime api-keys`, `runtime customer-apps`, `runtime deployment-profiles`, `runtime dlp-profiles`, `runtime scan-logs` | `SdkRuntimeService` (sync + async scan) + `SdkManagementService` (config CRUD) |
 | **AI Red Teaming** | `redteam scan`, `redteam targets`, `redteam prompt-sets`, `redteam prompts`, `redteam properties` | `SdkRedTeamService` + `SdkPromptSetService` |
 | **Model Security** | `model-security groups`, `model-security rules`, `model-security scans`, `model-security labels` | `SdkModelSecurityService` |
 | **Profile Audits** | `audit` | Audit runner + Scanner + LLM |
@@ -96,7 +96,7 @@ graph TD
 | **`config/`** | Zod schema with coercion and defaults; cascade loader merges CLI flags, env vars, config file, and defaults |
 | **`core/`** | AsyncGenerator loop that yields typed events, metric computation (TPR/TNR/F1), and AIRS constraint validation |
 | **`llm/`** | Factory for 6 LangChain providers, structured output with Zod schemas, and prompt templates for all 4 LLM calls |
-| **`airs/`** | Scanner (sync scan + batched concurrency), Runtime (sync + async bulk scan with polling), Management (topic CRUD + profile linking), Red Team (scan CRUD/polling/reports), Prompt Sets (custom prompt set management), Model Security (groups/rules/scans) |
+| **`airs/`** | Scanner (sync scan + batched concurrency), Runtime (sync + async bulk scan with polling), Management (topic CRUD, profile CRUD, API keys, customer apps, deployment/DLP profiles, scan logs), Red Team (scan CRUD/polling/reports), Prompt Sets (custom prompt set management), Model Security (groups/rules/scans) |
 | **`memory/`** | File-based learning store, LLM-driven extraction after each run, and budget-aware injection into future prompts |
 | **`persistence/`** | `JsonFileStore` serializes `RunState` to `~/.daystrom/runs/` for pause/resume support |
 | **`audit/`** | Profile-level multi-topic evaluation — generates tests per topic, computes per-topic and composite metrics, detects cross-topic conflicts |

--- a/docs/features/runtime-security.md
+++ b/docs/features/runtime-security.md
@@ -161,7 +161,6 @@ Daystrom exposes full CRUD over AIRS runtime configuration resources via `daystr
 
 ```bash
 daystrom runtime profiles list
-daystrom runtime profiles get <profileId>
 daystrom runtime profiles create --config profile.json
 daystrom runtime profiles update <profileId> --config profile.json
 daystrom runtime profiles delete <profileId>
@@ -172,7 +171,6 @@ daystrom runtime profiles delete <profileId> --force --updated-by user@example.c
 
 ```bash
 daystrom runtime topics list
-daystrom runtime topics get <topicId>
 daystrom runtime topics create --config topic.json
 daystrom runtime topics update <topicId> --config topic.json
 daystrom runtime topics delete <topicId>

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,14 @@ Daystrom is a CLI tool that provides full operational coverage over **Palo Alto 
 
     Optionally carry forward test prompts across iterations with dedup, catching regressions that fresh tests might miss.
 
+-   :material-shield-search:{ .lg .middle } **Runtime Security**
+
+    ---
+
+    Scan prompts against live security profiles and manage AIRS configuration — profiles, topics, API keys, customer apps, and scan logs via `daystrom runtime`.
+
+    [:octicons-arrow-right-24: Runtime Security](features/runtime-security.md)
+
 -   :material-sword:{ .lg .middle } **AI Red Teaming**
 
     ---

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -287,7 +287,6 @@ Security profile CRUD.
 
 ```bash
 daystrom runtime profiles list
-daystrom runtime profiles get <profileId>
 daystrom runtime profiles create --config <path>
 daystrom runtime profiles update <profileId> --config <path>
 daystrom runtime profiles delete <profileId>
@@ -297,7 +296,6 @@ daystrom runtime profiles delete <profileId> --force --updated-by <email>
 | Subcommand | Flags |
 |------------|-------|
 | `list` | — |
-| `get <profileId>` | — |
 | `create` | `--config <path>` (required) |
 | `update <profileId>` | `--config <path>` (required) |
 | `delete <profileId>` | `--force`, `--updated-by <email>` |
@@ -308,7 +306,6 @@ Custom topic CRUD.
 
 ```bash
 daystrom runtime topics list
-daystrom runtime topics get <topicId>
 daystrom runtime topics create --config <path>
 daystrom runtime topics update <topicId> --config <path>
 daystrom runtime topics delete <topicId>
@@ -318,7 +315,6 @@ daystrom runtime topics delete <topicId> --force --updated-by <email>
 | Subcommand | Flags |
 |------------|-------|
 | `list` | — |
-| `get <topicId>` | — |
 | `create` | `--config <path>` (required) |
 | `update <topicId>` | `--config <path>` (required) |
 | `delete <topicId>` | `--force`, `--updated-by <email>` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdot65/daystrom",
   "packageManager": "pnpm@10.6.5",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "CLI and library for Palo Alto Prisma AIRS — guardrail refinement, AI red teaming, model security scanning, profile audits",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Remove non-existent `profiles get` and `topics get` from CLI reference and runtime-security docs (SDK has no get method at any layer)
- Update architecture overview: add runtime config management commands to domain table, expand Management service description
- Add Runtime Security feature card to docs homepage (index.md)
- Improve README: docs link as prominent blockquote callout, add scan logs to command table
- Hotfix version bump to 1.14.2

Closes #177

## Test plan
- [x] All 537 tests pass
- [x] Lint, format, type check clean
- [x] `mkdocs build` succeeds
- [x] No code behavior changes — docs + version bump only

🤖 Generated with [Claude Code](https://claude.com/claude-code)